### PR TITLE
chore: init from cookiecutter-pyspark-databricks-serverless

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,61 @@
+# Poetry
+poetry.lock
+.venv/
+dist/
+
+# Python bytecode
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IDE specific files
+.idea/
+.vscode/
+*.swp
+*.swo
+.DS_Store
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# Logs
+*.log
+logs/
+
+# Local development settings
+local_settings.py
+
+# Database
+*.db
+*.sqlite3
+
+# Documentation
+docs/_build/
+site/
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Rope project settings
+.ropeproject

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+.PHONY: setup clean build test install
+
+POETRY = poetry
+
+setup:
+	$(POETRY) install
+
+build: setup
+	$(POETRY) build
+
+clean:
+	rm -rf dist/
+	rm -rf *.egg-info/
+	$(POETRY) env remove --all
+
+test: setup
+	$(POETRY) run pytest tests/
+
+install: setup
+	$(POETRY) install
+
+help:
+	@echo "Available commands:"
+	@echo "  make setup      - Install dependencies using Poetry"
+	@echo "  make build      - Build the package using Poetry"
+	@echo "  make clean      - Remove build artifacts and Poetry environment"
+	@echo "  make test       - Run tests"
+	@echo "  make install    - Install package in development mode"
+	@echo "  make help       - Show this help message"

--- a/claude_otel_session_scorer/__init__.py
+++ b/claude_otel_session_scorer/__init__.py
@@ -1,0 +1,7 @@
+"""
+A series of data pipelines for Databricks to score claude code sessions collected from Open Telemetry
+"""
+
+__version__ = "0.1.0"
+
+from claude_otel_session_scorer.main import main

--- a/claude_otel_session_scorer/main.py
+++ b/claude_otel_session_scorer/main.py
@@ -1,0 +1,43 @@
+import os
+from pyspark.sql import SparkSession, DataFrame
+from argparse import ArgumentParser
+
+
+def create_spark_session() -> SparkSession:
+    if os.environ.get("DATABRICKS_RUNTIME_VERSION") is None:
+        try:
+            from databricks.connect import DatabricksSession
+            return DatabricksSession.builder.serverless().getOrCreate()
+        except ImportError:
+            print("Databricks Connect not available. Falling back to standard Spark session.")
+            return SparkSession.builder.getOrCreate()
+    else:
+        return SparkSession.builder.getOrCreate()
+
+
+def scan_table(spark: SparkSession, table_name: str, limit: int = 10) -> DataFrame:
+    df: DataFrame = spark.table(table_name)
+    return df.limit(limit)
+
+
+def main() -> None:
+    parser = ArgumentParser(description="A series of data pipelines for Databricks to score claude code sessions collected from Open Telemetry")
+    parser.add_argument("--table-name", "-t", type=str, help="Name of the table to scan")
+    args = parser.parse_args()
+
+    spark: SparkSession = create_spark_session()
+
+    try:
+        result_df: DataFrame = scan_table(spark, args.table_name)
+        print(f"First 10 rows of table '{args.table_name}':")
+        result_df.show()
+        print(f"Schema of table '{args.table_name}':")
+        result_df.printSchema()
+    except Exception as e:
+        print(f"Error scanning table '{args.table_name}': {str(e)}")
+    finally:
+        spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/databricks.yml
+++ b/databricks.yml
@@ -1,0 +1,33 @@
+bundle:
+  name: "claude_otel_session_scorer"
+
+artifacts:
+  claude_otel_session_scorer:
+    type: whl
+    build: poetry build
+    path: .
+
+resources:
+  jobs:
+    claude_otel_session_scorer_job:
+      name: "Claude OTEL Session Scorer Job"
+      tasks:
+        - task_key: "main_task"
+          python_wheel_task:
+            package_name: "claude_otel_session_scorer"
+            entry_point: "main"
+            named_parameters:
+              table-name: "your_catalog.your_schema.your_table"
+          environment_key: Default
+      queue:
+        enabled: true
+      environments:
+        - environment_key: Default
+          spec:
+            client: "5"
+            dependencies:
+              - ./dist/*.whl
+
+targets:
+  dev:
+    default: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[tool.poetry]
+name = "claude_otel_session_scorer"
+version = "0.1.0"
+description = "A series of data pipelines for Databricks to score claude code sessions collected from Open Telemetry"
+authors = ["Tanner Wendland"]
+readme = "README.md"
+packages = [{include = "claude_otel_session_scorer"}]
+
+[tool.poetry.dependencies]
+python = "^3.12"
+databricks-connect = "==18.0.5"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.0.0"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.scripts]
+claude_otel_session_scorer = "claude_otel_session_scorer.main:main"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,31 @@
+"""
+Tests for the main module
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+
+from claude_otel_session_scorer.main import scan_table, create_spark_session
+
+
+@pytest.fixture
+def mock_spark():
+    """Create a mock Spark session for testing."""
+    with patch("claude_otel_session_scorer.main.SparkSession") as mock:
+        spark = MagicMock()
+        mock.builder.getOrCreate.return_value = spark
+        yield spark
+
+
+def test_scan_table(mock_spark):
+    """Test the scan_table function."""
+    mock_df = MagicMock()
+    mock_spark.table.return_value = mock_df
+
+    mock_result_df = MagicMock()
+    mock_df.limit.return_value = mock_result_df
+
+    result = scan_table(mock_spark, "test_table", limit=5)
+
+    mock_spark.table.assert_called_once_with("test_table")
+    mock_df.limit.assert_called_once_with(5)
+    assert result == mock_result_df


### PR DESCRIPTION
## Summary

- Scaffolds repo from `cookiecutter-pyspark-databricks-serverless` template
- Adds `pyproject.toml` (Poetry), `databricks.yml` (DAB bundle), package skeleton, and test structure
- Placeholder `main.py` follows the template pattern — will be replaced with Silver ETL and scoring jobs in follow-up PRs

## Structure

```
claude_otel_session_scorer/
  __init__.py
  main.py          ← placeholder, to be replaced
tests/
  test_main.py     ← placeholder tests
databricks.yml     ← DAB bundle config (python_wheel_task, serverless client 5)
pyproject.toml     ← Poetry build config
Makefile           ← setup / build / test targets
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)