### PR TITLE
ci: add lint, test, and build workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55  # v5.5.0
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Ruff check
+        run: ruff check .
+
+      - name: Ruff format check
+        run: ruff format --check .
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55  # v5.5.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Run tests
+        run: poetry run pytest tests/ -v
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55  # v5.5.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Build wheel
+        run: poetry build
+
+      - name: Check distribution
+        run: pip install twine && twine check dist/*

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: setup clean build test install
+.PHONY: setup clean build test install lint check fmt
 
 POETRY = poetry
 
@@ -14,10 +14,18 @@ clean:
 	$(POETRY) env remove --all
 
 test: setup
-	$(POETRY) run pytest tests/
+	$(POETRY) run pytest tests/ -v
 
 install: setup
 	$(POETRY) install
+
+lint:
+	ruff check . && ruff format --check .
+
+check: lint
+
+fmt:
+	ruff format .
 
 help:
 	@echo "Available commands:"
@@ -25,5 +33,8 @@ help:
 	@echo "  make build      - Build the package using Poetry"
 	@echo "  make clean      - Remove build artifacts and Poetry environment"
 	@echo "  make test       - Run tests"
+	@echo "  make lint       - Run ruff lint and format checks"
+	@echo "  make check      - Alias for lint (CI gate)"
+	@echo "  make fmt        - Auto-fix formatting with ruff"
 	@echo "  make install    - Install package in development mode"
 	@echo "  make help       - Show this help message"

--- a/claude_otel_session_scorer/__init__.py
+++ b/claude_otel_session_scorer/__init__.py
@@ -3,5 +3,3 @@ A series of data pipelines for Databricks to score claude code sessions collecte
 """
 
 __version__ = "0.1.0"
-
-from claude_otel_session_scorer.main import main

--- a/claude_otel_session_scorer/main.py
+++ b/claude_otel_session_scorer/main.py
@@ -7,6 +7,7 @@ def create_spark_session() -> SparkSession:
     if os.environ.get("DATABRICKS_RUNTIME_VERSION") is None:
         try:
             from databricks.connect import DatabricksSession
+
             return DatabricksSession.builder.serverless().getOrCreate()
         except ImportError:
             print("Databricks Connect not available. Falling back to standard Spark session.")
@@ -21,7 +22,9 @@ def scan_table(spark: SparkSession, table_name: str, limit: int = 10) -> DataFra
 
 
 def main() -> None:
-    parser = ArgumentParser(description="A series of data pipelines for Databricks to score claude code sessions collected from Open Telemetry")
+    parser = ArgumentParser(
+        description="A series of data pipelines for Databricks to score claude code sessions collected from Open Telemetry"
+    )
     parser.add_argument("--table-name", "-t", type=str, help="Name of the table to scan")
     args = parser.parse_args()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ databricks-connect = "==18.0.5"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0.0"
+ruff = ">=0.4"
 
 [build-system]
 requires = ["poetry-core"]
@@ -19,3 +20,12 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
 claude_otel_session_scorer = "claude_otel_session_scorer.main:main"
+
+[tool.ruff]
+line-length = 100
+
+[tool.pytest.ini_options]
+log_cli = true
+log_cli_level = "INFO"
+log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{include = "claude_otel_session_scorer"}]
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = ">=3.12,<3.13"
 databricks-connect = "==18.0.5"
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,7 +4,7 @@ Tests for the main module
 import pytest
 from unittest.mock import patch, MagicMock
 
-from claude_otel_session_scorer.main import scan_table, create_spark_session
+from claude_otel_session_scorer.main import scan_table
 
 
 @pytest.fixture

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 """
 Tests for the main module
 """
+
 import pytest
 from unittest.mock import patch, MagicMock
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` with three jobs: `lint`, `test`, `build`
- **lint**: ruff check + ruff format check (pinned action SHAs)
- **test**: Poetry install + pytest
- **build**: Poetry build + twine check (validates wheel/sdist metadata)
- Updates `pyproject.toml`: adds `ruff>=0.4` dev dep, `[tool.ruff]` config (`line-length = 100`), and `[tool.pytest.ini_options]`
- Updates `Makefile`: adds `lint`, `check`, `fmt` targets matching CI

Inspired by `uc-catalog-mcp` and `databricks-claude` CI patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)