### PR TITLE
feat: Silver ETL job — bronze OTEL → session_summary, session_events, session_metrics

### DIFF
--- a/claude_otel_session_scorer/silver_etl.py
+++ b/claude_otel_session_scorer/silver_etl.py
@@ -1,0 +1,590 @@
+"""Silver ETL job: transform bronze OTEL tables into session-level silver tables.
+
+Reads from <source_catalog>.<source_schema>.{traces, metrics, logs} and writes
+session_summary, session_events, and session_metrics into the target schema.
+"""
+
+import argparse
+import logging
+import os
+
+from pyspark.sql import Column, DataFrame, SparkSession
+from pyspark.sql import functions as F
+from pyspark.sql.window import Window
+
+logger = logging.getLogger(__name__)
+
+
+def create_spark_session() -> SparkSession:
+    """Create or get the active Spark session.
+
+    Mirrors the pattern used in main.py: use DatabricksSession serverless when
+    running locally with databricks-connect, otherwise fall back to standard
+    PySpark (used both on Databricks runtime and in tests).
+    """
+    if os.environ.get("DATABRICKS_RUNTIME_VERSION") is None:
+        try:
+            from databricks.connect import DatabricksSession
+
+            return DatabricksSession.builder.serverless().getOrCreate()
+        except ImportError:
+            print("Databricks Connect not available. Falling back to standard Spark session.")
+            return SparkSession.builder.getOrCreate()
+    else:
+        return SparkSession.builder.getOrCreate()
+
+
+def _safe_event_attr(attr_key: str) -> Column:
+    """Return the value of ``events[0].attributes[attr_key]`` if any events exist.
+
+    Avoids errors on rows where ``events`` is empty/null by guarding with
+    ``size(events) > 0``.
+    """
+    return F.when(
+        F.size(F.col("events")) > 0,
+        F.col("events")[0]["attributes"].getItem(attr_key),
+    )
+
+
+# ---------------------------------------------------------------------------
+# session_summary
+# ---------------------------------------------------------------------------
+
+
+def transform_session_summary(traces_df: DataFrame, metrics_df: DataFrame) -> DataFrame:
+    """Aggregate bronze traces + metrics into a per-session summary row."""
+
+    interactions = (
+        traces_df.filter(F.col("name") == "claude_code.interaction")
+        .groupBy(F.col("attributes").getItem("session.id").alias("session_id"))
+        .agg(
+            F.first(F.col("attributes").getItem("user.id")).alias("user_id"),
+            F.count("*").alias("num_interactions"),
+            F.min((F.col("start_time_unix_nano") / 1e9).cast("timestamp")).alias("session_start"),
+            F.max((F.col("end_time_unix_nano") / 1e9).cast("timestamp")).alias("session_end"),
+            F.avg(F.col("attributes").getItem("user_prompt_length").cast("int")).alias(
+                "avg_prompt_length"
+            ),
+            F.first(F.col("resource.attributes").getItem("service.version")).alias(
+                "service_version"
+            ),
+            F.first(F.col("resource.attributes").getItem("os.type")).alias("os_type"),
+            F.first(F.col("attributes").getItem("terminal.type")).alias("terminal_type"),
+        )
+    )
+
+    llm_stats = (
+        traces_df.filter(F.col("name") == "claude_code.llm_request")
+        .groupBy(F.col("attributes").getItem("session.id").alias("session_id"))
+        .agg(
+            F.count("*").alias("num_llm_requests"),
+            F.sum(F.col("attributes").getItem("input_tokens").cast("long")).alias(
+                "total_input_tokens"
+            ),
+            F.sum(F.col("attributes").getItem("output_tokens").cast("long")).alias(
+                "total_output_tokens"
+            ),
+            F.sum(F.col("attributes").getItem("cache_read_tokens").cast("long")).alias(
+                "total_cache_read"
+            ),
+            F.sum(F.col("attributes").getItem("cache_creation_tokens").cast("long")).alias(
+                "total_cache_creation"
+            ),
+            F.avg(F.col("attributes").getItem("ttft_ms").cast("double")).alias("avg_ttft_ms"),
+            F.avg(F.col("attributes").getItem("duration_ms").cast("double")).alias(
+                "avg_llm_duration_ms"
+            ),
+        )
+    )
+
+    tool_stats = (
+        traces_df.filter(F.col("name") == "claude_code.tool")
+        .groupBy(F.col("attributes").getItem("session.id").alias("session_id"))
+        .agg(
+            F.count("*").alias("num_tool_calls"),
+            F.countDistinct(F.col("attributes").getItem("tool_name")).alias("distinct_tools"),
+        )
+    )
+
+    tool_exec = (
+        traces_df.filter(F.col("name") == "claude_code.tool.execution")
+        .groupBy(F.col("attributes").getItem("session.id").alias("session_id"))
+        .agg(
+            F.count("*").alias("num_tool_executions"),
+            F.sum(
+                F.when(F.col("attributes").getItem("success") == "true", 1).otherwise(0)
+            ).alias("tool_successes"),
+        )
+    )
+
+    autonomy = (
+        traces_df.filter(F.col("name") == "claude_code.tool.blocked_on_user")
+        .groupBy(F.col("attributes").getItem("session.id").alias("session_id"))
+        .agg(
+            F.count("*").alias("num_blocked_on_user"),
+            F.sum(
+                F.when(F.col("attributes").getItem("decision") == "accept", 1).otherwise(0)
+            ).alias("auto_accepted"),
+        )
+    )
+
+    cost = (
+        metrics_df.filter(F.col("name") == "claude_code.cost.usage")
+        .groupBy(F.col("sum.attributes").getItem("session.id").alias("session_id"))
+        .agg(F.sum("sum.value").alias("total_cost_usd"))
+    )
+
+    active_time = (
+        metrics_df.filter(F.col("name") == "claude_code.active_time.total")
+        .groupBy(F.col("sum.attributes").getItem("session.id").alias("session_id"))
+        .agg(F.sum("sum.value").alias("total_active_time_s"))
+    )
+
+    session_summary = (
+        interactions.join(llm_stats, "session_id", "left")
+        .join(tool_stats, "session_id", "left")
+        .join(tool_exec, "session_id", "left")
+        .join(autonomy, "session_id", "left")
+        .join(cost, "session_id", "left")
+        .join(active_time, "session_id", "left")
+        .withColumn(
+            "session_duration_s",
+            F.unix_timestamp("session_end") - F.unix_timestamp("session_start"),
+        )
+        .withColumn(
+            "cache_hit_rate",
+            F.coalesce(F.col("total_cache_read"), F.lit(0))
+            / F.greatest(
+                F.col("total_input_tokens")
+                + F.col("total_output_tokens")
+                + F.coalesce(F.col("total_cache_read"), F.lit(0))
+                + F.coalesce(F.col("total_cache_creation"), F.lit(0)),
+                F.lit(1),
+            ),
+        )
+        .withColumn(
+            "tool_success_rate",
+            F.when(
+                F.col("num_tool_executions") > 0,
+                F.col("tool_successes") / F.col("num_tool_executions"),
+            ),
+        )
+        .withColumn(
+            "auto_accept_rate",
+            F.when(
+                F.col("num_blocked_on_user") > 0,
+                F.col("auto_accepted") / F.col("num_blocked_on_user"),
+            ),
+        )
+        .withColumn(
+            "tools_per_interaction",
+            F.when(
+                F.col("num_interactions") > 0,
+                F.col("num_tool_calls") / F.col("num_interactions"),
+            ),
+        )
+        .withColumn(
+            "llm_calls_per_interaction",
+            F.when(
+                F.col("num_interactions") > 0,
+                F.col("num_llm_requests") / F.col("num_interactions"),
+            ),
+        )
+        .select(
+            "session_id",
+            "user_id",
+            "session_start",
+            "session_end",
+            "session_duration_s",
+            "num_interactions",
+            "num_llm_requests",
+            "num_tool_calls",
+            "total_input_tokens",
+            "total_output_tokens",
+            "total_cache_read",
+            "total_cache_creation",
+            "cache_hit_rate",
+            "avg_ttft_ms",
+            "avg_llm_duration_ms",
+            "tool_success_rate",
+            "auto_accept_rate",
+            "tools_per_interaction",
+            "llm_calls_per_interaction",
+            "avg_prompt_length",
+            "total_cost_usd",
+            "total_active_time_s",
+            "service_version",
+            "os_type",
+            "terminal_type",
+        )
+    )
+
+    return session_summary
+
+
+# ---------------------------------------------------------------------------
+# session_events
+# ---------------------------------------------------------------------------
+
+
+def transform_session_events(traces_df: DataFrame, logs_df: DataFrame) -> DataFrame:
+    """Build a unified per-session timeline of events.
+
+    Sources six event types from traces (user prompts, tool calls, tool results,
+    api errors, internal errors, llm requests) plus warning/error log records.
+    """
+
+    session_id = F.col("attributes").getItem("session.id").alias("session_id")
+    start_ts = (F.col("start_time_unix_nano") / 1e9).cast("timestamp").alias("event_time")
+
+    # ── USER_PROMPT events from claude_code.interaction spans ──
+    user_prompts = (
+        traces_df.filter(F.col("name") == "claude_code.interaction")
+        .select(
+            session_id,
+            start_ts,
+            F.lit("USER_PROMPT").alias("event_type"),
+            F.lit(None).cast("string").alias("error_category"),
+            F.col("attributes").getItem("user_prompt_length").cast("int").alias("prompt_length"),
+            F.lit(None).cast("string").alias("tool_name"),
+            F.lit(None).cast("string").alias("error_message"),
+            F.substring(_safe_event_attr("prompt"), 1, 500).alias("content_preview"),
+        )
+    )
+
+    # ── TOOL_CALL ──
+    tool_calls = (
+        traces_df.filter(F.col("name") == "claude_code.tool")
+        .select(
+            session_id,
+            start_ts,
+            F.lit("TOOL_CALL").alias("event_type"),
+            F.lit(None).cast("string").alias("error_category"),
+            F.lit(None).cast("int").alias("prompt_length"),
+            F.col("attributes").getItem("tool_name").alias("tool_name"),
+            F.lit(None).cast("string").alias("error_message"),
+            F.lit(None).cast("string").alias("content_preview"),
+        )
+    )
+
+    # ── TOOL_RESULT ──
+    tool_results = (
+        traces_df.filter(F.col("name") == "claude_code.tool.execution")
+        .select(
+            session_id,
+            start_ts,
+            F.lit("TOOL_RESULT").alias("event_type"),
+            F.lit(None).cast("string").alias("error_category"),
+            F.lit(None).cast("int").alias("prompt_length"),
+            F.col("attributes").getItem("tool_name").alias("tool_name"),
+            F.lit(None).cast("string").alias("error_message"),
+            F.substring(_safe_event_attr("result"), 1, 500).alias("content_preview"),
+        )
+    )
+
+    # ── api_error spans → ERROR / BACKGROUND_ABORTED / USER_ABORTED ──
+    api_errors = (
+        traces_df.filter(F.col("name") == "claude_code.api_error")
+        .withColumn("query_source", F.col("attributes").getItem("query_source"))
+        .withColumn("error_msg", F.col("attributes").getItem("error"))
+        .select(
+            session_id,
+            start_ts,
+            F.when(F.col("query_source") == "away_summary", F.lit("BACKGROUND_ABORTED"))
+            .when(F.col("error_msg") == "Request was aborted.", F.lit("USER_ABORTED"))
+            .otherwise(F.lit("ERROR"))
+            .alias("event_type"),
+            F.when(F.col("query_source") == "away_summary", F.lit("invisible"))
+            .when(F.col("error_msg") == "Request was aborted.", F.lit("invisible"))
+            .otherwise(F.lit("user_visible"))
+            .alias("error_category"),
+            F.lit(None).cast("int").alias("prompt_length"),
+            F.lit(None).cast("string").alias("tool_name"),
+            F.col("error_msg").alias("error_message"),
+            F.lit(None).cast("string").alias("content_preview"),
+        )
+    )
+
+    # ── internal_error spans → INTERNAL_ERROR / invisible ──
+    internal_errors = (
+        traces_df.filter(F.col("name") == "claude_code.internal_error")
+        .select(
+            session_id,
+            start_ts,
+            F.lit("INTERNAL_ERROR").alias("event_type"),
+            F.lit("invisible").alias("error_category"),
+            F.lit(None).cast("int").alias("prompt_length"),
+            F.lit(None).cast("string").alias("tool_name"),
+            F.col("attributes").getItem("error").alias("error_message"),
+            F.lit(None).cast("string").alias("content_preview"),
+        )
+    )
+
+    # ── LLM_REQUEST ──
+    llm_requests = (
+        traces_df.filter(F.col("name") == "claude_code.llm_request")
+        .select(
+            session_id,
+            start_ts,
+            F.lit("LLM_REQUEST").alias("event_type"),
+            F.lit(None).cast("string").alias("error_category"),
+            F.lit(None).cast("int").alias("prompt_length"),
+            F.lit(None).cast("string").alias("tool_name"),
+            F.lit(None).cast("string").alias("error_message"),
+            F.lit(None).cast("string").alias("content_preview"),
+        )
+    )
+
+    columns = [
+        "session_id",
+        "event_time",
+        "event_type",
+        "error_category",
+        "prompt_length",
+        "tool_name",
+        "error_message",
+        "content_preview",
+    ]
+
+    unioned = (
+        user_prompts.select(*columns)
+        .unionByName(tool_calls.select(*columns))
+        .unionByName(tool_results.select(*columns))
+        .unionByName(api_errors.select(*columns))
+        .unionByName(internal_errors.select(*columns))
+        .unionByName(llm_requests.select(*columns))
+    )
+
+    if logs_df is not None and "body" in logs_df.columns:
+        log_events = logs_df.select(
+            F.col("attributes").getItem("session.id").alias("session_id"),
+            F.lit(None).cast("timestamp").alias("event_time"),
+            F.lit("LOG").alias("event_type"),
+            F.lit(None).cast("string").alias("error_category"),
+            F.lit(None).cast("int").alias("prompt_length"),
+            F.lit(None).cast("string").alias("tool_name"),
+            F.lit(None).cast("string").alias("error_message"),
+            F.substring(F.col("body"), 1, 500).alias("content_preview"),
+        ).filter(F.col("session_id").isNotNull())
+        unioned = unioned.unionByName(log_events.select(*columns))
+
+    return unioned
+
+
+# ---------------------------------------------------------------------------
+# session_metrics
+# ---------------------------------------------------------------------------
+
+
+def transform_session_metrics(metrics_df: DataFrame) -> DataFrame:
+    """Aggregate bronze metrics into per-session token + cost + model snapshot."""
+
+    tokens_df = (
+        metrics_df.filter(F.col("name") == "claude_code.token.usage")
+        .groupBy(F.col("sum.attributes").getItem("session.id").alias("session_id"))
+        .agg(
+            F.sum(
+                F.when(
+                    F.col("sum.attributes").getItem("type") == "input", F.col("sum.value")
+                ).otherwise(0)
+            ).alias("input_tokens"),
+            F.sum(
+                F.when(
+                    F.col("sum.attributes").getItem("type") == "output", F.col("sum.value")
+                ).otherwise(0)
+            ).alias("output_tokens"),
+            F.sum(
+                F.when(
+                    F.col("sum.attributes").getItem("type") == "cacheRead", F.col("sum.value")
+                ).otherwise(0)
+            ).alias("cache_read_tokens"),
+            F.sum(
+                F.when(
+                    F.col("sum.attributes").getItem("type") == "cacheCreation",
+                    F.col("sum.value"),
+                ).otherwise(0)
+            ).alias("cache_creation_tokens"),
+        )
+    )
+
+    cost_df = (
+        metrics_df.filter(F.col("name") == "claude_code.cost.usage")
+        .groupBy(F.col("sum.attributes").getItem("session.id").alias("session_id"))
+        .agg(F.sum("sum.value").alias("total_cost_usd"))
+    )
+
+    active_time_df = (
+        metrics_df.filter(F.col("name") == "claude_code.active_time.total")
+        .groupBy(F.col("sum.attributes").getItem("session.id").alias("session_id"))
+        .agg(F.sum("sum.value").alias("total_active_time_s"))
+    )
+
+    lines_df = (
+        metrics_df.filter(F.col("name") == "claude_code.code_edit_tool.decision")
+        .groupBy(F.col("sum.attributes").getItem("session.id").alias("session_id"))
+        .agg(F.sum("sum.value").alias("code_edit_decisions"))
+    )
+
+    model_effort = (
+        metrics_df.filter(F.col("name") == "claude_code.cost.usage")
+        .select(
+            F.col("sum.attributes").getItem("session.id").alias("session_id"),
+            F.col("sum.attributes").getItem("model").alias("model"),
+            F.col("sum.attributes").getItem("effort").alias("effort"),
+            F.col("sum.value").alias("cost"),
+        )
+        .groupBy("session_id", "model", "effort")
+        .agg(F.sum("cost").alias("model_cost"))
+        .withColumn(
+            "rn",
+            F.row_number().over(
+                Window.partitionBy("session_id").orderBy(F.col("model_cost").desc())
+            ),
+        )
+        .filter(F.col("rn") == 1)
+        .select(
+            "session_id",
+            F.col("model").alias("primary_model"),
+            F.col("effort").alias("effort_level"),
+        )
+    )
+
+    session_metrics = (
+        tokens_df.join(cost_df, "session_id", "outer")
+        .join(active_time_df, "session_id", "outer")
+        .join(lines_df, "session_id", "outer")
+        .join(model_effort, "session_id", "left")
+        .select(
+            "session_id",
+            "input_tokens",
+            "output_tokens",
+            "cache_read_tokens",
+            "cache_creation_tokens",
+            "total_cost_usd",
+            "total_active_time_s",
+            "code_edit_decisions",
+            "primary_model",
+            "effort_level",
+        )
+    )
+
+    return session_metrics
+
+
+# ---------------------------------------------------------------------------
+# Writers
+# ---------------------------------------------------------------------------
+
+
+def _merge_table(spark: SparkSession, df: DataFrame, target_table: str, merge_key: str) -> None:
+    """Upsert ``df`` into ``target_table`` keyed on ``merge_key`` using Delta MERGE.
+
+    Creates the table from ``df`` on first run.
+    """
+    staging_view = f"_silver_etl_staging_{merge_key}"
+    df.createOrReplaceTempView(staging_view)
+
+    if not spark.catalog.tableExists(target_table):
+        logger.info("Creating target table %s", target_table)
+        df.write.format("delta").saveAsTable(target_table)
+        return
+
+    logger.info("Merging into %s on %s", target_table, merge_key)
+    update_cols = [c for c in df.columns if c != merge_key]
+    set_clause = ", ".join(f"t.{c} = s.{c}" for c in update_cols)
+    insert_cols = ", ".join(df.columns)
+    insert_vals = ", ".join(f"s.{c}" for c in df.columns)
+
+    spark.sql(
+        f"""
+        MERGE INTO {target_table} t
+        USING {staging_view} s
+        ON t.{merge_key} = s.{merge_key}
+        WHEN MATCHED THEN UPDATE SET {set_clause}
+        WHEN NOT MATCHED THEN INSERT ({insert_cols}) VALUES ({insert_vals})
+        """
+    )
+
+
+def _delete_append_table(spark: SparkSession, df: DataFrame, target_table: str) -> None:
+    """Replace ``target_table`` contents with ``df`` (overwrite semantics)."""
+    logger.info("Overwriting %s", target_table)
+    (
+        df.write.format("delta")
+        .mode("overwrite")
+        .option("overwriteSchema", "true")
+        .saveAsTable(target_table)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+def run_silver_etl(
+    spark: SparkSession,
+    source_catalog: str,
+    source_schema: str,
+    target_catalog: str,
+    target_schema: str,
+) -> None:
+    """Read bronze tables, run the three transforms, write silver tables."""
+
+    traces_table = f"{source_catalog}.{source_schema}.traces"
+    metrics_table = f"{source_catalog}.{source_schema}.metrics"
+    logs_table = f"{source_catalog}.{source_schema}.logs"
+
+    logger.info(
+        "Reading bronze tables: %s, %s, %s", traces_table, metrics_table, logs_table
+    )
+    traces_df = spark.read.table(traces_table)
+    metrics_df = spark.read.table(metrics_table)
+    logs_df = spark.read.table(logs_table)
+
+    spark.sql(f"CREATE SCHEMA IF NOT EXISTS {target_catalog}.{target_schema}")
+
+    summary_df = transform_session_summary(traces_df, metrics_df)
+    events_df = transform_session_events(traces_df, logs_df)
+    metrics_silver_df = transform_session_metrics(metrics_df)
+
+    _merge_table(
+        spark,
+        summary_df,
+        f"{target_catalog}.{target_schema}.session_summary",
+        "session_id",
+    )
+    _delete_append_table(
+        spark, events_df, f"{target_catalog}.{target_schema}.session_events"
+    )
+    _merge_table(
+        spark,
+        metrics_silver_df,
+        f"{target_catalog}.{target_schema}.session_metrics",
+        "session_id",
+    )
+
+
+def main() -> None:
+    """CLI entry point — parses args and runs the silver ETL."""
+    logging.basicConfig(level=logging.INFO)
+
+    parser = argparse.ArgumentParser(description="Run the silver ETL job.")
+    parser.add_argument("--source-catalog", default="tanner_fevm_catalog")
+    parser.add_argument("--source-schema", default="claude")
+    parser.add_argument("--target-catalog", default="tanner_fevm_catalog")
+    parser.add_argument("--target-schema", default="claude_silver")
+    args = parser.parse_args()
+
+    spark = create_spark_session()
+    run_silver_etl(
+        spark,
+        source_catalog=args.source_catalog,
+        source_schema=args.source_schema,
+        target_catalog=args.target_catalog,
+        target_schema=args.target_schema,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/databricks.yml
+++ b/databricks.yml
@@ -28,6 +28,27 @@ resources:
             dependencies:
               - ./dist/*.whl
 
+    silver_etl_job:
+      name: "Silver ETL Job"
+      tasks:
+        - task_key: "silver_etl_task"
+          python_wheel_task:
+            package_name: "claude_otel_session_scorer"
+            entry_point: "silver_etl"
+            named_parameters:
+              source-catalog: "tanner_fevm_catalog"
+              source-schema: "claude"
+              target-catalog: "tanner_fevm_catalog"
+              target-schema: "claude_silver"
+      queue:
+        enabled: true
+      environments:
+        - environment_key: Default
+          spec:
+            client: "5"
+            dependencies:
+              - ./dist/*.whl
+
 targets:
   dev:
     default: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ databricks-connect = "==18.0.5"
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.0.0"
 ruff = ">=0.4"
+pyspark = ">=4.0.0"
 
 [build-system]
 requires = ["poetry-core"]
@@ -20,6 +21,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
 claude_otel_session_scorer = "claude_otel_session_scorer.main:main"
+silver_etl = "claude_otel_session_scorer.silver_etl:main"
 
 [tool.ruff]
 line-length = 100

--- a/tests/test_silver_etl.py
+++ b/tests/test_silver_etl.py
@@ -1,0 +1,464 @@
+"""Local PySpark tests for the silver ETL transforms.
+
+Uses a session-scoped local Spark session — no Databricks Connect.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pyspark.sql import SparkSession
+from pyspark.sql.types import (
+    ArrayType,
+    DoubleType,
+    IntegerType,
+    LongType,
+    MapType,
+    StringType,
+    StructField,
+    StructType,
+)
+
+from claude_otel_session_scorer.silver_etl import (
+    transform_session_events,
+    transform_session_metrics,
+    transform_session_summary,
+)
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+TRACES_SCHEMA = StructType(
+    [
+        StructField("trace_id", StringType(), True),
+        StructField("span_id", StringType(), True),
+        StructField("name", StringType(), True),
+        StructField("start_time_unix_nano", LongType(), True),
+        StructField("end_time_unix_nano", LongType(), True),
+        StructField("attributes", MapType(StringType(), StringType()), True),
+        StructField(
+            "resource",
+            StructType(
+                [
+                    StructField("attributes", MapType(StringType(), StringType()), True),
+                ]
+            ),
+            True,
+        ),
+        StructField(
+            "events",
+            ArrayType(
+                StructType(
+                    [
+                        StructField("time_unix_nano", LongType(), True),
+                        StructField("name", StringType(), True),
+                        StructField(
+                            "attributes", MapType(StringType(), StringType()), True
+                        ),
+                        StructField("dropped_attributes_count", IntegerType(), True),
+                    ]
+                )
+            ),
+            True,
+        ),
+    ]
+)
+
+METRICS_SCHEMA = StructType(
+    [
+        StructField("name", StringType(), True),
+        StructField(
+            "sum",
+            StructType(
+                [
+                    StructField("value", DoubleType(), True),
+                    StructField(
+                        "attributes", MapType(StringType(), StringType()), True
+                    ),
+                ]
+            ),
+            True,
+        ),
+    ]
+)
+
+LOGS_SCHEMA = StructType(
+    [
+        StructField("body", StringType(), True),
+        StructField("attributes", MapType(StringType(), StringType()), True),
+    ]
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def spark() -> SparkSession:
+    return (
+        SparkSession.builder.master("local[1]")
+        .appName("test_silver_etl")
+        .config("spark.sql.shuffle.partitions", "1")
+        .config("spark.ui.enabled", "false")
+        .getOrCreate()
+    )
+
+
+def _trace_row(
+    *,
+    name: str,
+    session_id: str,
+    start: int = 1_000_000_000_000_000_000,
+    end: int = 2_000_000_000_000_000_000,
+    attributes: dict | None = None,
+    resource_attrs: dict | None = None,
+    events: list | None = None,
+):
+    attrs = {"session.id": session_id}
+    if attributes:
+        attrs.update(attributes)
+    return (
+        "trace",
+        "span",
+        name,
+        start,
+        end,
+        attrs,
+        {"attributes": resource_attrs or {}},
+        events or [],
+    )
+
+
+def _metric_row(*, name: str, value: float, attributes: dict):
+    return (name, {"value": value, "attributes": attributes})
+
+
+# ---------------------------------------------------------------------------
+# session_summary
+# ---------------------------------------------------------------------------
+
+
+def test_session_summary_joins_all_aggregates_and_derives_columns(spark: SparkSession):
+    sid = "s1"
+    traces = spark.createDataFrame(
+        [
+            # interactions (2 of them)
+            _trace_row(
+                name="claude_code.interaction",
+                session_id=sid,
+                attributes={
+                    "user.id": "u1",
+                    "user_prompt_length": "100",
+                    "terminal.type": "iTerm",
+                },
+                resource_attrs={"service.version": "1.2.3", "os.type": "darwin"},
+                start=1_700_000_000_000_000_000,
+                end=1_700_000_010_000_000_000,
+            ),
+            _trace_row(
+                name="claude_code.interaction",
+                session_id=sid,
+                attributes={
+                    "user.id": "u1",
+                    "user_prompt_length": "200",
+                    "terminal.type": "iTerm",
+                },
+                resource_attrs={"service.version": "1.2.3", "os.type": "darwin"},
+                start=1_700_000_020_000_000_000,
+                end=1_700_000_030_000_000_000,
+            ),
+            # llm_request
+            _trace_row(
+                name="claude_code.llm_request",
+                session_id=sid,
+                attributes={
+                    "input_tokens": "100",
+                    "output_tokens": "50",
+                    "cache_read_tokens": "200",
+                    "cache_creation_tokens": "10",
+                    "ttft_ms": "120.0",
+                    "duration_ms": "1000.0",
+                },
+            ),
+            # tool calls (4) — 4 / 2 interactions = 2.0 tools per interaction
+            _trace_row(
+                name="claude_code.tool",
+                session_id=sid,
+                attributes={"tool_name": "Read"},
+            ),
+            _trace_row(
+                name="claude_code.tool",
+                session_id=sid,
+                attributes={"tool_name": "Read"},
+            ),
+            _trace_row(
+                name="claude_code.tool",
+                session_id=sid,
+                attributes={"tool_name": "Edit"},
+            ),
+            _trace_row(
+                name="claude_code.tool",
+                session_id=sid,
+                attributes={"tool_name": "Bash"},
+            ),
+            # tool execution: 3 of 4 succeed
+            _trace_row(
+                name="claude_code.tool.execution",
+                session_id=sid,
+                attributes={"success": "true"},
+            ),
+            _trace_row(
+                name="claude_code.tool.execution",
+                session_id=sid,
+                attributes={"success": "true"},
+            ),
+            _trace_row(
+                name="claude_code.tool.execution",
+                session_id=sid,
+                attributes={"success": "true"},
+            ),
+            _trace_row(
+                name="claude_code.tool.execution",
+                session_id=sid,
+                attributes={"success": "false"},
+            ),
+            # blocked_on_user: 2 of 4 auto-accepted
+            _trace_row(
+                name="claude_code.tool.blocked_on_user",
+                session_id=sid,
+                attributes={"decision": "accept"},
+            ),
+            _trace_row(
+                name="claude_code.tool.blocked_on_user",
+                session_id=sid,
+                attributes={"decision": "accept"},
+            ),
+            _trace_row(
+                name="claude_code.tool.blocked_on_user",
+                session_id=sid,
+                attributes={"decision": "reject"},
+            ),
+            _trace_row(
+                name="claude_code.tool.blocked_on_user",
+                session_id=sid,
+                attributes={"decision": "reject"},
+            ),
+        ],
+        schema=TRACES_SCHEMA,
+    )
+
+    metrics = spark.createDataFrame(
+        [
+            _metric_row(
+                name="claude_code.cost.usage",
+                value=1.25,
+                attributes={"session.id": sid, "model": "sonnet", "effort": "high"},
+            ),
+            _metric_row(
+                name="claude_code.active_time.total",
+                value=42.0,
+                attributes={"session.id": sid},
+            ),
+        ],
+        schema=METRICS_SCHEMA,
+    )
+
+    out = transform_session_summary(traces, metrics).collect()
+    assert len(out) == 1
+    row = out[0].asDict()
+
+    assert row["session_id"] == sid
+    assert row["user_id"] == "u1"
+    assert row["num_interactions"] == 2
+    assert row["num_llm_requests"] == 1
+    assert row["num_tool_calls"] == 4
+    assert row["total_input_tokens"] == 100
+    assert row["total_output_tokens"] == 50
+    assert row["total_cache_read"] == 200
+    assert row["total_cache_creation"] == 10
+
+    # cache_hit_rate = 200 / (100 + 50 + 200 + 10) = 200/360
+    assert row["cache_hit_rate"] == pytest.approx(200 / 360)
+    # tool_success_rate = 3/4
+    assert row["tool_success_rate"] == pytest.approx(0.75)
+    # auto_accept_rate = 2/4
+    assert row["auto_accept_rate"] == pytest.approx(0.5)
+    # tools_per_interaction = 4/2
+    assert row["tools_per_interaction"] == pytest.approx(2.0)
+    # llm_calls_per_interaction = 1/2
+    assert row["llm_calls_per_interaction"] == pytest.approx(0.5)
+
+    assert row["total_cost_usd"] == pytest.approx(1.25)
+    assert row["total_active_time_s"] == pytest.approx(42.0)
+    assert row["service_version"] == "1.2.3"
+    assert row["os_type"] == "darwin"
+    assert row["terminal_type"] == "iTerm"
+
+
+# ---------------------------------------------------------------------------
+# session_events
+# ---------------------------------------------------------------------------
+
+
+def test_session_events_error_classification_branches(spark: SparkSession):
+    sid = "s1"
+    traces = spark.createDataFrame(
+        [
+            # internal_error → INTERNAL_ERROR / invisible
+            _trace_row(
+                name="claude_code.internal_error",
+                session_id=sid,
+                attributes={"error": "Boom"},
+            ),
+            # api_error + away_summary → BACKGROUND_ABORTED / invisible
+            _trace_row(
+                name="claude_code.api_error",
+                session_id=sid,
+                attributes={"query_source": "away_summary", "error": "rate limited"},
+            ),
+            # api_error + Request was aborted. → USER_ABORTED / invisible
+            _trace_row(
+                name="claude_code.api_error",
+                session_id=sid,
+                attributes={
+                    "query_source": "user",
+                    "error": "Request was aborted.",
+                },
+            ),
+            # api_error other → ERROR / user_visible
+            _trace_row(
+                name="claude_code.api_error",
+                session_id=sid,
+                attributes={"query_source": "user", "error": "500 server fail"},
+            ),
+        ],
+        schema=TRACES_SCHEMA,
+    )
+    logs = spark.createDataFrame([], schema=LOGS_SCHEMA)
+
+    out = transform_session_events(traces, logs).collect()
+    by_type = {(r["event_type"], r["error_category"]) for r in out}
+
+    assert ("INTERNAL_ERROR", "invisible") in by_type
+    assert ("BACKGROUND_ABORTED", "invisible") in by_type
+    assert ("USER_ABORTED", "invisible") in by_type
+    assert ("ERROR", "user_visible") in by_type
+
+
+def test_session_events_truncates_content_preview_at_500_chars(spark: SparkSession):
+    sid = "s1"
+    long_prompt = "p" * 1200
+    long_result = "r" * 1200
+
+    traces = spark.createDataFrame(
+        [
+            _trace_row(
+                name="claude_code.interaction",
+                session_id=sid,
+                attributes={"user_prompt_length": "1200"},
+                events=[
+                    (
+                        1_700_000_000_000_000_000,
+                        "user_prompt",
+                        {"prompt": long_prompt},
+                        0,
+                    )
+                ],
+            ),
+            _trace_row(
+                name="claude_code.tool.execution",
+                session_id=sid,
+                attributes={"tool_name": "Bash", "success": "true"},
+                events=[
+                    (
+                        1_700_000_001_000_000_000,
+                        "tool_result",
+                        {"result": long_result},
+                        0,
+                    )
+                ],
+            ),
+        ],
+        schema=TRACES_SCHEMA,
+    )
+    logs = spark.createDataFrame([], schema=LOGS_SCHEMA)
+
+    out = transform_session_events(traces, logs).collect()
+    previews = {r["event_type"]: r["content_preview"] for r in out if r["content_preview"]}
+
+    assert "USER_PROMPT" in previews
+    assert "TOOL_RESULT" in previews
+    assert len(previews["USER_PROMPT"]) == 500
+    assert len(previews["TOOL_RESULT"]) == 500
+    assert previews["USER_PROMPT"] == "p" * 500
+    assert previews["TOOL_RESULT"] == "r" * 500
+
+
+# ---------------------------------------------------------------------------
+# session_metrics
+# ---------------------------------------------------------------------------
+
+
+def test_session_metrics_token_pivot_and_primary_model(spark: SparkSession):
+    sid = "s1"
+    metrics = spark.createDataFrame(
+        [
+            # token usage rows
+            _metric_row(
+                name="claude_code.token.usage",
+                value=100.0,
+                attributes={"session.id": sid, "type": "input"},
+            ),
+            _metric_row(
+                name="claude_code.token.usage",
+                value=50.0,
+                attributes={"session.id": sid, "type": "output"},
+            ),
+            _metric_row(
+                name="claude_code.token.usage",
+                value=200.0,
+                attributes={"session.id": sid, "type": "cacheRead"},
+            ),
+            _metric_row(
+                name="claude_code.token.usage",
+                value=10.0,
+                attributes={"session.id": sid, "type": "cacheCreation"},
+            ),
+            # cost: cheap model first, then expensive model — expensive should win
+            _metric_row(
+                name="claude_code.cost.usage",
+                value=0.10,
+                attributes={"session.id": sid, "model": "haiku", "effort": "low"},
+            ),
+            _metric_row(
+                name="claude_code.cost.usage",
+                value=2.50,
+                attributes={"session.id": sid, "model": "opus", "effort": "high"},
+            ),
+            _metric_row(
+                name="claude_code.cost.usage",
+                value=0.50,
+                attributes={"session.id": sid, "model": "sonnet", "effort": "medium"},
+            ),
+        ],
+        schema=METRICS_SCHEMA,
+    )
+
+    out = transform_session_metrics(metrics).collect()
+    assert len(out) == 1
+    row = out[0].asDict()
+
+    assert row["session_id"] == sid
+    assert row["input_tokens"] == pytest.approx(100.0)
+    assert row["output_tokens"] == pytest.approx(50.0)
+    assert row["cache_read_tokens"] == pytest.approx(200.0)
+    assert row["cache_creation_tokens"] == pytest.approx(10.0)
+
+    # primary_model should be the most expensive: opus
+    assert row["primary_model"] == "opus"
+    assert row["effort_level"] == "high"
+    # total_cost_usd = 0.10 + 2.50 + 0.50
+    assert row["total_cost_usd"] == pytest.approx(3.10)


### PR DESCRIPTION
Closes #3

Productionalizes the Silver ETL notebook as a Python wheel job.

- `silver_etl.py`: transform functions for session_summary, session_events, session_metrics
- `test_silver_etl.py`: local PySpark tests covering all error branches, derived formulas, token pivot
- `pyproject.toml`: adds `silver_etl` script entry point
- `databricks.yml`: adds `silver_etl_job` with serverless compute and named parameters

🦀 *(via claw)*