### PR TITLE
feat: incremental scoring job (session_scores gold table)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,9 @@ dmypy.json
 
 # Rope project settings
 .ropeproject
+
+# Oh my claude code
+.omc/
+
+# Databricks Automation Bundles
+.databricks/

--- a/claude_otel_session_scorer/scorer.py
+++ b/claude_otel_session_scorer/scorer.py
@@ -45,10 +45,12 @@ JUDGMENT_SCHEMA = StructType(
 
 
 def create_spark_session() -> SparkSession:
+    """Return (or reuse) the active SparkSession for this job."""
     return SparkSession.builder.appName("claude_otel_score_sessions").getOrCreate()
 
 
 def format_event_line(row) -> str:
+    """Render a single session event as a human-readable line for the LLM replay."""
     ts = getattr(row, "event_ts", "")
     etype = getattr(row, "event_type", "")
     name = getattr(row, "detail_name", "")
@@ -62,6 +64,7 @@ def format_event_line(row) -> str:
 
 
 def split_into_interactions(rows: list) -> list[list]:
+    """Partition events into interactions, splitting at each USER_PROMPT boundary."""
     interactions: list[list] = []
     current: list = []
     for row in rows:
@@ -75,6 +78,7 @@ def split_into_interactions(rows: list) -> list[list]:
 
 
 def compress_interaction(events: list) -> str:
+    """Summarise a middle interaction as a single compressed line to save replay budget."""
     from collections import Counter
 
     counts = Counter(getattr(r, "event_type", "UNKNOWN") for r in events)
@@ -85,6 +89,7 @@ def compress_interaction(events: list) -> str:
 
 
 def build_replay_text(rows: list) -> str:
+    """Build the session replay string, keeping head/tail verbatim and compressing the middle."""
     interactions = split_into_interactions(rows)
     if len(interactions) <= KEEP_INTERACTIONS * 2:
         text = "\n".join(format_event_line(r) for r in rows)
@@ -105,6 +110,7 @@ def build_replay_text(rows: list) -> str:
 
 @F.udf(StringType())
 def _build_replay_udf(rows):
+    """Spark UDF wrapper — collect_list rows → replay text for each session."""
     return build_replay_text(rows or [])
 
 
@@ -117,6 +123,7 @@ def _build_prompt_udf(
     tool_success_rate,
     auto_accept_rate,
 ):
+    """Spark UDF that renders the LLM judge prompt from session metrics and replay text."""
     replay = replay_text or "(no events)"
     cost = total_cost_usd or 0.0
     chr_rate = f"{(cache_hit_rate or 0):.2%}"
@@ -146,6 +153,7 @@ def _build_prompt_udf(
 def run_scoring(
     spark: SparkSession, target_catalog: str, target_schema: str, gold_schema: str
 ) -> None:
+    """Run the full incremental scoring pipeline: discover → replay → score → judge → merge."""
     silver_summary = f"{target_catalog}.{target_schema}.session_summary"
     silver_events = f"{target_catalog}.{target_schema}.session_events"
     gold_scores = f"{gold_schema}.session_scores"
@@ -356,6 +364,7 @@ def run_scoring(
 
 
 def main() -> None:
+    """Entry point: parse args, create Spark session, run scoring, stop Spark."""
     parser = ArgumentParser(description="Score Claude Code sessions using LLM-as-judge")
     parser.add_argument("--target-catalog", required=True)
     parser.add_argument("--target-schema", required=True)

--- a/claude_otel_session_scorer/scorer.py
+++ b/claude_otel_session_scorer/scorer.py
@@ -175,15 +175,19 @@ def run_scoring(
     silver_events = f"{target_catalog}.{target_schema}.session_events"
     gold_scores = f"{gold_schema}.session_scores"
 
+    # Only score sessions whose last span ended before the start of today (UTC),
+    # ensuring the session is complete before committing an immutable score.
+    completed_sessions_df = spark.table(silver_summary).filter(
+        F.col("session_end") < F.date_trunc("day", F.current_timestamp())
+    )
+
     if spark.catalog.tableExists(gold_scores):
         existing = spark.table(gold_scores).select("session_id")
-        new_sessions_df = (
-            spark.table(silver_summary)
-            .select("session_id")
-            .join(existing, "session_id", "left_anti")
+        new_sessions_df = completed_sessions_df.select("session_id").join(
+            existing, "session_id", "left_anti"
         )
     else:
-        new_sessions_df = spark.table(silver_summary).select("session_id")
+        new_sessions_df = completed_sessions_df.select("session_id")
 
     count = new_sessions_df.count()
     if count == 0:
@@ -231,7 +235,9 @@ def run_scoring(
 
     scored_df = (
         silver_df.join(visible_errors, "session_id", "left")
-        .withColumn("visible_error_count", F.coalesce(F.col("visible_error_count"), F.lit(0)))
+        .withColumn(
+            "visible_error_count", F.coalesce(F.col("visible_error_count"), F.lit(0))
+        )
         .withColumn(
             "efficiency_score",
             F.least(
@@ -242,7 +248,9 @@ def run_scoring(
                     F.lit(40.0)
                     - (
                         F.col("total_cost_usd")
-                        / F.greatest(F.col("num_interactions").cast("double"), F.lit(1.0))
+                        / F.greatest(
+                            F.col("num_interactions").cast("double"), F.lit(1.0)
+                        )
                     )
                     * 400,
                 ),
@@ -256,7 +264,9 @@ def run_scoring(
                     F.lit(50.0),
                     (
                         F.col("num_tool_calls")
-                        / F.greatest(F.col("num_interactions").cast("double"), F.lit(1.0))
+                        / F.greatest(
+                            F.col("num_interactions").cast("double"), F.lit(1.0)
+                        )
                     )
                     * 25,
                 )
@@ -274,7 +284,9 @@ def run_scoring(
                 ),
             ),
         )
-        .withColumn("autonomy_score", F.coalesce(F.col("auto_accept_rate"), F.lit(0.0)) * 100)
+        .withColumn(
+            "autonomy_score", F.coalesce(F.col("auto_accept_rate"), F.lit(0.0)) * 100
+        )
         .withColumn(
             "engagement_score",
             F.least(
@@ -283,7 +295,9 @@ def run_scoring(
                     F.lit(50.0),
                     F.col("session_duration_s").cast("double") / 60 * 50,
                 )
-                + F.least(F.lit(50.0), F.coalesce(F.col("avg_prompt_length"), F.lit(0.0))),
+                + F.least(
+                    F.lit(50.0), F.coalesce(F.col("avg_prompt_length"), F.lit(0.0))
+                ),
             ),
         )
         .withColumn(

--- a/claude_otel_session_scorer/scorer.py
+++ b/claude_otel_session_scorer/scorer.py
@@ -1,0 +1,370 @@
+"""Incremental LLM-as-judge scoring pipeline for Claude Code sessions."""
+
+from __future__ import annotations
+
+import logging
+from argparse import ArgumentParser
+from datetime import datetime, timezone
+
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as F
+from pyspark.sql.types import IntegerType, StringType, StructField, StructType
+
+logger = logging.getLogger(__name__)
+
+REPLAY_CHAR_BUDGET = 30_000
+KEEP_INTERACTIONS = 2
+
+RESPONSE_FORMAT = (
+    '{"type":"json_object","schema":{"type":"object","properties":{"judgment":{"type":"object",'
+    '"properties":{"task_clarity":{"type":"integer"},"agent_effectiveness":{"type":"integer"},'
+    '"tool_strategy":{"type":"integer"},"error_handling":{"type":"integer"},'
+    '"cost_efficiency":{"type":"integer"},"overall_score":{"type":"integer"},'
+    '"summary":{"type":"string"},"recommendations":{"type":"string"}}}}}}'
+)
+
+JUDGMENT_SCHEMA = StructType(
+    [
+        StructField(
+            "judgment",
+            StructType(
+                [
+                    StructField("task_clarity", IntegerType()),
+                    StructField("agent_effectiveness", IntegerType()),
+                    StructField("tool_strategy", IntegerType()),
+                    StructField("error_handling", IntegerType()),
+                    StructField("cost_efficiency", IntegerType()),
+                    StructField("overall_score", IntegerType()),
+                    StructField("summary", StringType()),
+                    StructField("recommendations", StringType()),
+                ]
+            ),
+        )
+    ]
+)
+
+
+def create_spark_session() -> SparkSession:
+    return SparkSession.builder.appName("claude_otel_score_sessions").getOrCreate()
+
+
+def format_event_line(row) -> str:
+    ts = getattr(row, "event_ts", "")
+    etype = getattr(row, "event_type", "")
+    name = getattr(row, "detail_name", "")
+    model = getattr(row, "model", "")
+    inp = getattr(row, "input_tokens", 0) or 0
+    out = getattr(row, "output_tokens", 0) or 0
+    cost = getattr(row, "cost_usd", 0.0) or 0.0
+    err = getattr(row, "error_category", "") or ""
+    preview = (getattr(row, "content_preview", "") or "")[:200]
+    return f"{ts} [{etype}] {name} model={model} tokens={inp}/{out} cost=${cost:.4f} err={err} | {preview}"
+
+
+def split_into_interactions(rows: list) -> list[list]:
+    interactions: list[list] = []
+    current: list = []
+    for row in rows:
+        if getattr(row, "event_type", "") == "USER_PROMPT" and current:
+            interactions.append(current)
+            current = []
+        current.append(row)
+    if current:
+        interactions.append(current)
+    return interactions or [[]]
+
+
+def compress_interaction(events: list) -> str:
+    from collections import Counter
+
+    counts = Counter(getattr(r, "event_type", "UNKNOWN") for r in events)
+    type_str = " ".join(f"{k}={v}" for k, v in counts.most_common())
+    total_cost = sum(getattr(r, "cost_usd", 0.0) or 0.0 for r in events)
+    total_ms = sum(getattr(r, "duration_ms", 0) or 0 for r in events)
+    return f"--- [compressed: {len(events)} events, types: {type_str}, cost=${total_cost:.4f}, duration={total_ms}ms] ---"
+
+
+def build_replay_text(rows: list) -> str:
+    interactions = split_into_interactions(rows)
+    if len(interactions) <= KEEP_INTERACTIONS * 2:
+        text = "\n".join(format_event_line(r) for r in rows)
+    else:
+        keep_head = interactions[:KEEP_INTERACTIONS]
+        keep_tail = interactions[-KEEP_INTERACTIONS:]
+        middle = interactions[KEEP_INTERACTIONS:-KEEP_INTERACTIONS]
+        parts: list[str] = []
+        for chunk in keep_head:
+            parts.extend(format_event_line(r) for r in chunk)
+        for chunk in middle:
+            parts.append(compress_interaction(chunk))
+        for chunk in keep_tail:
+            parts.extend(format_event_line(r) for r in chunk)
+        text = "\n".join(parts)
+    return text[:REPLAY_CHAR_BUDGET]
+
+
+@F.udf(StringType())
+def _build_replay_udf(rows):
+    return build_replay_text(rows or [])
+
+
+@F.udf(StringType())
+def _build_prompt_udf(
+    replay_text,
+    num_interactions,
+    total_cost_usd,
+    cache_hit_rate,
+    tool_success_rate,
+    auto_accept_rate,
+):
+    replay = replay_text or "(no events)"
+    cost = total_cost_usd or 0.0
+    chr_rate = f"{(cache_hit_rate or 0):.2%}"
+    tsr = f"{(tool_success_rate or 0):.2f}"
+    aar = f"{(auto_accept_rate or 0):.2f}"
+    return (
+        "You are evaluating a Claude Code AI agent session. Score each dimension 0-100.\n\n"
+        "IMPORTANT: INTERNAL_ERROR, BACKGROUND_ABORTED, and USER_ABORTED events are normal "
+        "operational events - do NOT penalize for them.\n\n"
+        f"Session replay:\n{replay}\n\n"
+        f"Session metrics:\n"
+        f"- interactions: {num_interactions}, cost: ${cost:.4f}, cache_hit_rate: {chr_rate}\n"
+        f"- tool_success_rate: {tsr}, auto_accept_rate: {aar}\n\n"
+        "Score dimensions (0-100):\n"
+        "- task_clarity (15%): how clearly defined and focused was the task?\n"
+        "- agent_effectiveness (25%): did the agent accomplish its goals?\n"
+        "- tool_strategy (25%): were tools used efficiently and appropriately?\n"
+        "- error_handling (15%): how well were errors managed?\n"
+        "- cost_efficiency (20%): was token/cost usage appropriate?\n"
+        "- overall_score: weighted summary of the above\n"
+        "- summary: one paragraph\n"
+        "- recommendations: actionable suggestions\n\n"
+        "Return JSON only."
+    )
+
+
+def run_scoring(
+    spark: SparkSession, target_catalog: str, target_schema: str, gold_schema: str
+) -> None:
+    silver_summary = f"{target_catalog}.{target_schema}.session_summary"
+    silver_events = f"{target_catalog}.{target_schema}.session_events"
+    gold_scores = f"{gold_schema}.session_scores"
+
+    if spark.catalog.tableExists(gold_scores):
+        existing = spark.table(gold_scores).select("session_id")
+        new_sessions_df = (
+            spark.table(silver_summary)
+            .select("session_id")
+            .join(existing, "session_id", "left_anti")
+        )
+    else:
+        new_sessions_df = spark.table(silver_summary).select("session_id")
+
+    count = new_sessions_df.count()
+    if count == 0:
+        logger.info("No new sessions to score.")
+        return
+
+    logger.info("Scoring %d new sessions.", count)
+
+    events_df = (
+        spark.table(silver_events)
+        .join(new_sessions_df, "session_id")
+        .orderBy("session_id", "event_ts")
+    )
+    replay_df = (
+        events_df.groupBy("session_id")
+        .agg(
+            F.collect_list(
+                F.struct(
+                    "event_ts",
+                    "event_type",
+                    "detail_name",
+                    "model",
+                    "input_tokens",
+                    "output_tokens",
+                    "cost_usd",
+                    "error_category",
+                    "content_preview",
+                    "duration_ms",
+                )
+            ).alias("events")
+        )
+        .withColumn("replay_text", _build_replay_udf(F.col("events")))
+        .select("session_id", "replay_text")
+    )
+
+    visible_errors = (
+        spark.table(silver_events)
+        .join(new_sessions_df, "session_id")
+        .filter(F.col("error_category") == "user_visible")
+        .groupBy("session_id")
+        .agg(F.count("*").alias("visible_error_count"))
+    )
+
+    silver_df = spark.table(silver_summary).join(new_sessions_df, "session_id")
+
+    scored_df = (
+        silver_df.join(visible_errors, "session_id", "left")
+        .withColumn("visible_error_count", F.coalesce(F.col("visible_error_count"), F.lit(0)))
+        .withColumn(
+            "efficiency_score",
+            F.least(
+                F.lit(100.0),
+                F.col("cache_hit_rate") * 60
+                + F.greatest(
+                    F.lit(0.0),
+                    F.lit(40.0)
+                    - (
+                        F.col("total_cost_usd")
+                        / F.greatest(F.col("num_interactions").cast("double"), F.lit(1.0))
+                    )
+                    * 400,
+                ),
+            ),
+        )
+        .withColumn(
+            "productivity_score",
+            F.least(
+                F.lit(100.0),
+                F.least(
+                    F.lit(50.0),
+                    (
+                        F.col("num_tool_calls")
+                        / F.greatest(F.col("num_interactions").cast("double"), F.lit(1.0))
+                    )
+                    * 25,
+                )
+                + F.least(F.lit(50.0), F.col("num_interactions").cast("double") * 10),
+            ),
+        )
+        .withColumn(
+            "quality_score",
+            F.least(
+                F.lit(100.0),
+                F.coalesce(F.col("tool_success_rate"), F.lit(1.0)) * 70
+                + F.greatest(
+                    F.lit(0.0),
+                    F.lit(30.0) - F.col("visible_error_count").cast("double") * 15,
+                ),
+            ),
+        )
+        .withColumn("autonomy_score", F.coalesce(F.col("auto_accept_rate"), F.lit(0.0)) * 100)
+        .withColumn(
+            "engagement_score",
+            F.least(
+                F.lit(100.0),
+                F.least(
+                    F.lit(50.0),
+                    F.col("session_duration_s").cast("double") / 60 * 50,
+                )
+                + F.least(F.lit(50.0), F.coalesce(F.col("avg_prompt_length"), F.lit(0.0))),
+            ),
+        )
+        .withColumn(
+            "composite_score",
+            F.col("efficiency_score") * 0.20
+            + F.col("productivity_score") * 0.25
+            + F.col("quality_score") * 0.20
+            + F.col("autonomy_score") * 0.15
+            + F.col("engagement_score") * 0.20,
+        )
+    )
+
+    with_prompt = scored_df.join(replay_df, "session_id", "left").withColumn(
+        "full_prompt",
+        _build_prompt_udf(
+            F.col("replay_text"),
+            F.col("num_interactions"),
+            F.col("total_cost_usd"),
+            F.col("cache_hit_rate"),
+            F.col("tool_success_rate"),
+            F.col("auto_accept_rate"),
+        ),
+    )
+
+    ai_result = with_prompt.withColumn(
+        "ai_response",
+        F.expr(
+            f"ai_query('databricks-claude-sonnet-4', full_prompt, responseFormat => '{RESPONSE_FORMAT}')"
+        ),
+    ).withColumn(
+        "judgment", F.from_json(F.col("ai_response"), JUDGMENT_SCHEMA).getField("judgment")
+    )
+
+    gold_df = ai_result.select(
+        "session_id",
+        "user_id",
+        "session_start",
+        "num_interactions",
+        "total_cost_usd",
+        "efficiency_score",
+        "productivity_score",
+        "quality_score",
+        "autonomy_score",
+        "engagement_score",
+        "composite_score",
+        F.col("judgment.task_clarity").alias("llm_task_clarity"),
+        F.col("judgment.agent_effectiveness").alias("llm_agent_effectiveness"),
+        F.col("judgment.tool_strategy").alias("llm_tool_strategy"),
+        F.col("judgment.error_handling").alias("llm_error_handling"),
+        F.col("judgment.cost_efficiency").alias("llm_cost_efficiency"),
+        F.col("judgment.overall_score").alias("llm_overall_score"),
+        F.col("judgment.summary").alias("llm_summary"),
+        F.col("judgment.recommendations").alias("llm_recommendations"),
+        F.lit(datetime.now(timezone.utc)).cast("timestamp").alias("scored_at"),
+    )
+
+    spark.sql(
+        f"""
+        CREATE TABLE IF NOT EXISTS {gold_scores} (
+            session_id STRING,
+            user_id STRING,
+            session_start TIMESTAMP,
+            num_interactions LONG,
+            total_cost_usd DOUBLE,
+            efficiency_score DOUBLE,
+            productivity_score DOUBLE,
+            quality_score DOUBLE,
+            autonomy_score DOUBLE,
+            engagement_score DOUBLE,
+            composite_score DOUBLE,
+            llm_task_clarity INT,
+            llm_agent_effectiveness INT,
+            llm_tool_strategy INT,
+            llm_error_handling INT,
+            llm_cost_efficiency INT,
+            llm_overall_score INT,
+            llm_summary STRING,
+            llm_recommendations STRING,
+            scored_at TIMESTAMP
+        ) USING DELTA
+        """
+    )
+
+    gold_df.createOrReplaceTempView("session_scores_updates")
+    spark.sql(
+        f"""
+        MERGE INTO {gold_scores} AS target
+        USING session_scores_updates AS source
+        ON target.session_id = source.session_id
+        WHEN MATCHED THEN UPDATE SET *
+        WHEN NOT MATCHED THEN INSERT *
+        """
+    )
+    logger.info("Scored %d sessions into %s.", count, gold_scores)
+
+
+def main() -> None:
+    parser = ArgumentParser(description="Score Claude Code sessions using LLM-as-judge")
+    parser.add_argument("--target-catalog", required=True)
+    parser.add_argument("--target-schema", required=True)
+    parser.add_argument(
+        "--gold-schema", required=True, help="Full catalog.schema, e.g. prod.claude_gold"
+    )
+    args = parser.parse_args()
+    spark = create_spark_session()
+    try:
+        run_scoring(spark, args.target_catalog, args.target_schema, args.gold_schema)
+    finally:
+        spark.stop()

--- a/claude_otel_session_scorer/scorer.py
+++ b/claude_otel_session_scorer/scorer.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 
 from pyspark.sql import SparkSession
 from pyspark.sql import functions as F
-from pyspark.sql.types import IntegerType, StringType, StructField, StructType
+from pyspark.sql.types import StringType
 
 logger = logging.getLogger(__name__)
 
@@ -17,31 +17,16 @@ _REPLAY_CHAR_BUDGET = 30_000
 _KEEP_INTERACTIONS = 2
 
 RESPONSE_FORMAT = (
-    '{"type":"json_object","schema":{"type":"object","properties":{"judgment":{"type":"object",'
-    '"properties":{"task_clarity":{"type":"integer"},"agent_effectiveness":{"type":"integer"},'
-    '"tool_strategy":{"type":"integer"},"error_handling":{"type":"integer"},'
-    '"cost_efficiency":{"type":"integer"},"overall_score":{"type":"integer"},'
-    '"summary":{"type":"string"},"recommendations":{"type":"string"}}}}}}'
+    "STRUCT<judgment STRUCT<"
+    "task_clarity INT, agent_effectiveness INT, tool_strategy INT, "
+    "error_handling INT, cost_efficiency INT, overall_score INT, "
+    "summary STRING, recommendations STRING>>"
 )
 
-JUDGMENT_SCHEMA = StructType(
-    [
-        StructField(
-            "judgment",
-            StructType(
-                [
-                    StructField("task_clarity", IntegerType()),
-                    StructField("agent_effectiveness", IntegerType()),
-                    StructField("tool_strategy", IntegerType()),
-                    StructField("error_handling", IntegerType()),
-                    StructField("cost_efficiency", IntegerType()),
-                    StructField("overall_score", IntegerType()),
-                    StructField("summary", StringType()),
-                    StructField("recommendations", StringType()),
-                ]
-            ),
-        )
-    ]
+FLAT_SCHEMA = (
+    "task_clarity INT, agent_effectiveness INT, tool_strategy INT, "
+    "error_handling INT, cost_efficiency INT, overall_score INT, "
+    "summary STRING, recommendations STRING"
 )
 
 
@@ -178,7 +163,7 @@ def run_scoring(
     # Only score sessions whose last span ended before the start of today (UTC),
     # ensuring the session is complete before committing an immutable score.
     completed_sessions_df = spark.table(silver_summary).filter(
-        F.col("session_end") < F.date_trunc("day", F.current_timestamp())
+        F.col("session_end") < F.current_timestamp() - F.expr("INTERVAL 2 HOURS")
     )
 
     if spark.catalog.tableExists(gold_scores):
@@ -196,26 +181,24 @@ def run_scoring(
 
     logger.info("Scoring %d new sessions.", count)
 
-    events_df = (
-        spark.table(silver_events)
-        .join(new_sessions_df, "session_id")
-        .orderBy("session_id", "event_ts")
-    )
+    events_df = spark.table(silver_events).join(new_sessions_df, "session_id")
     replay_df = (
         events_df.groupBy("session_id")
         .agg(
-            F.collect_list(
-                F.struct(
-                    "event_ts",
-                    "event_type",
-                    "detail_name",
-                    "model",
-                    "input_tokens",
-                    "output_tokens",
-                    "cost_usd",
-                    "error_category",
-                    "content_preview",
-                    "duration_ms",
+            F.sort_array(
+                F.collect_list(
+                    F.struct(
+                        "event_ts",
+                        "event_type",
+                        "detail_name",
+                        "model",
+                        "input_tokens",
+                        "output_tokens",
+                        "cost_usd",
+                        "error_category",
+                        "content_preview",
+                        "duration_ms",
+                    )
                 )
             ).alias("events")
         )
@@ -240,12 +223,12 @@ def run_scoring(
             "efficiency_score",
             F.least(
                 F.lit(100.0),
-                F.col("cache_hit_rate") * 60
+                F.coalesce(F.col("cache_hit_rate"), F.lit(0.0)) * 60
                 + F.greatest(
                     F.lit(0.0),
                     F.lit(40.0)
                     - (
-                        F.col("total_cost_usd")
+                        F.coalesce(F.col("total_cost_usd"), F.lit(0.0))
                         / F.greatest(F.col("num_interactions").cast("double"), F.lit(1.0))
                     )
                     * 400,
@@ -259,7 +242,7 @@ def run_scoring(
                 F.least(
                     F.lit(50.0),
                     (
-                        F.col("num_tool_calls")
+                        F.coalesce(F.col("num_tool_calls"), F.lit(0))
                         / F.greatest(F.col("num_interactions").cast("double"), F.lit(1.0))
                     )
                     * 25,
@@ -285,7 +268,7 @@ def run_scoring(
                 F.lit(100.0),
                 F.least(
                     F.lit(50.0),
-                    F.col("session_duration_s").cast("double") / 60 * 50,
+                    F.coalesce(F.col("session_duration_s"), F.lit(0.0)).cast("double") / 60 * 50,
                 )
                 + F.least(F.lit(50.0), F.coalesce(F.col("avg_prompt_length"), F.lit(0.0))),
             ),
@@ -319,7 +302,7 @@ def run_scoring(
         ),
     ).withColumn(
         "judgment",
-        F.from_json(F.col("ai_response"), JUDGMENT_SCHEMA).getField("judgment"),
+        F.from_json(F.col("ai_response"), FLAT_SCHEMA),
     )
 
     gold_df = ai_result.select(
@@ -344,7 +327,9 @@ def run_scoring(
         F.col("judgment.recommendations").alias("llm_recommendations"),
         F.lit(datetime.now(timezone.utc)).cast("timestamp").alias("scored_at"),
     )
+    gold_df = gold_df.filter(F.col("llm_overall_score").isNotNull())
 
+    spark.sql(f"CREATE SCHEMA IF NOT EXISTS {gold_schema}")
     spark.sql(
         f"""
         CREATE TABLE IF NOT EXISTS {gold_scores} (
@@ -401,4 +386,5 @@ def main() -> None:
     try:
         run_scoring(spark, args.target_catalog, args.target_schema, args.gold_schema)
     finally:
-        spark.stop()
+        if os.environ.get("DATABRICKS_RUNTIME_VERSION") is None:
+            spark.stop()

--- a/claude_otel_session_scorer/scorer.py
+++ b/claude_otel_session_scorer/scorer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from argparse import ArgumentParser
 from datetime import datetime, timezone
 
@@ -12,8 +13,8 @@ from pyspark.sql.types import IntegerType, StringType, StructField, StructType
 
 logger = logging.getLogger(__name__)
 
-REPLAY_CHAR_BUDGET = 30_000
-KEEP_INTERACTIONS = 2
+_REPLAY_CHAR_BUDGET = 30_000
+_KEEP_INTERACTIONS = 2
 
 RESPONSE_FORMAT = (
     '{"type":"json_object","schema":{"type":"object","properties":{"judgment":{"type":"object",'
@@ -46,7 +47,14 @@ JUDGMENT_SCHEMA = StructType(
 
 def create_spark_session() -> SparkSession:
     """Return (or reuse) the active SparkSession for this job."""
-    return SparkSession.builder.appName("claude_otel_score_sessions").getOrCreate()
+    if os.environ.get("DATABRICKS_RUNTIME_VERSION") is None:
+        try:
+            from databricks.connect import DatabricksSession
+
+            return DatabricksSession.builder.serverless().getOrCreate()
+        except ImportError:
+            return SparkSession.builder.getOrCreate()
+    return SparkSession.builder.getOrCreate()
 
 
 def format_event_line(row) -> str:
@@ -88,15 +96,19 @@ def compress_interaction(events: list) -> str:
     return f"--- [compressed: {len(events)} events, types: {type_str}, cost=${total_cost:.4f}, duration={total_ms}ms] ---"
 
 
-def build_replay_text(rows: list) -> str:
+def build_replay_text(
+    rows: list,
+    replay_char_budget: int = _REPLAY_CHAR_BUDGET,
+    keep_interactions: int = _KEEP_INTERACTIONS,
+) -> str:
     """Build the session replay string, keeping head/tail verbatim and compressing the middle."""
     interactions = split_into_interactions(rows)
-    if len(interactions) <= KEEP_INTERACTIONS * 2:
+    if len(interactions) <= keep_interactions * 2:
         text = "\n".join(format_event_line(r) for r in rows)
     else:
-        keep_head = interactions[:KEEP_INTERACTIONS]
-        keep_tail = interactions[-KEEP_INTERACTIONS:]
-        middle = interactions[KEEP_INTERACTIONS:-KEEP_INTERACTIONS]
+        keep_head = interactions[:keep_interactions]
+        keep_tail = interactions[-keep_interactions:]
+        middle = interactions[keep_interactions:-keep_interactions]
         parts: list[str] = []
         for chunk in keep_head:
             parts.extend(format_event_line(r) for r in chunk)
@@ -105,7 +117,7 @@ def build_replay_text(rows: list) -> str:
         for chunk in keep_tail:
             parts.extend(format_event_line(r) for r in chunk)
         text = "\n".join(parts)
-    return text[:REPLAY_CHAR_BUDGET]
+    return text[:replay_char_budget]
 
 
 @F.udf(StringType())
@@ -151,7 +163,12 @@ def _build_prompt_udf(
 
 
 def run_scoring(
-    spark: SparkSession, target_catalog: str, target_schema: str, gold_schema: str
+    spark: SparkSession,
+    target_catalog: str,
+    target_schema: str,
+    gold_schema: str,
+    replay_char_budget: int = _REPLAY_CHAR_BUDGET,
+    keep_interactions: int = _KEEP_INTERACTIONS,
 ) -> None:
     """Run the full incremental scoring pipeline: discover → replay → score → judge → merge."""
     silver_summary = f"{target_catalog}.{target_schema}.session_summary"
@@ -297,7 +314,8 @@ def run_scoring(
             f"ai_query('databricks-claude-sonnet-4', full_prompt, responseFormat => '{RESPONSE_FORMAT}')"
         ),
     ).withColumn(
-        "judgment", F.from_json(F.col("ai_response"), JUDGMENT_SCHEMA).getField("judgment")
+        "judgment",
+        F.from_json(F.col("ai_response"), JUDGMENT_SCHEMA).getField("judgment"),
     )
 
     gold_df = ai_result.select(
@@ -347,6 +365,7 @@ def run_scoring(
             llm_recommendations STRING,
             scored_at TIMESTAMP
         ) USING DELTA
+        CLUSTER BY AUTO
         """
     )
 
@@ -369,7 +388,9 @@ def main() -> None:
     parser.add_argument("--target-catalog", required=True)
     parser.add_argument("--target-schema", required=True)
     parser.add_argument(
-        "--gold-schema", required=True, help="Full catalog.schema, e.g. prod.claude_gold"
+        "--gold-schema",
+        required=True,
+        help="Full catalog.schema, e.g. prod.claude_gold",
     )
     args = parser.parse_args()
     spark = create_spark_session()

--- a/claude_otel_session_scorer/scorer.py
+++ b/claude_otel_session_scorer/scorer.py
@@ -235,9 +235,7 @@ def run_scoring(
 
     scored_df = (
         silver_df.join(visible_errors, "session_id", "left")
-        .withColumn(
-            "visible_error_count", F.coalesce(F.col("visible_error_count"), F.lit(0))
-        )
+        .withColumn("visible_error_count", F.coalesce(F.col("visible_error_count"), F.lit(0)))
         .withColumn(
             "efficiency_score",
             F.least(
@@ -248,9 +246,7 @@ def run_scoring(
                     F.lit(40.0)
                     - (
                         F.col("total_cost_usd")
-                        / F.greatest(
-                            F.col("num_interactions").cast("double"), F.lit(1.0)
-                        )
+                        / F.greatest(F.col("num_interactions").cast("double"), F.lit(1.0))
                     )
                     * 400,
                 ),
@@ -264,9 +260,7 @@ def run_scoring(
                     F.lit(50.0),
                     (
                         F.col("num_tool_calls")
-                        / F.greatest(
-                            F.col("num_interactions").cast("double"), F.lit(1.0)
-                        )
+                        / F.greatest(F.col("num_interactions").cast("double"), F.lit(1.0))
                     )
                     * 25,
                 )
@@ -284,9 +278,7 @@ def run_scoring(
                 ),
             ),
         )
-        .withColumn(
-            "autonomy_score", F.coalesce(F.col("auto_accept_rate"), F.lit(0.0)) * 100
-        )
+        .withColumn("autonomy_score", F.coalesce(F.col("auto_accept_rate"), F.lit(0.0)) * 100)
         .withColumn(
             "engagement_score",
             F.least(
@@ -295,9 +287,7 @@ def run_scoring(
                     F.lit(50.0),
                     F.col("session_duration_s").cast("double") / 60 * 50,
                 )
-                + F.least(
-                    F.lit(50.0), F.coalesce(F.col("avg_prompt_length"), F.lit(0.0))
-                ),
+                + F.least(F.lit(50.0), F.coalesce(F.col("avg_prompt_length"), F.lit(0.0))),
             ),
         )
         .withColumn(

--- a/claude_otel_session_scorer/scorer.py
+++ b/claude_otel_session_scorer/scorer.py
@@ -218,68 +218,59 @@ def run_scoring(
 
     scored_df = (
         silver_df.join(visible_errors, "session_id", "left")
-        .withColumn("visible_error_count", F.coalesce(F.col("visible_error_count"), F.lit(0)))
+        .withColumn("visible_error_count", F.expr("COALESCE(visible_error_count, 0)"))
         .withColumn(
             "efficiency_score",
-            F.least(
-                F.lit(100.0),
-                F.coalesce(F.col("cache_hit_rate"), F.lit(0.0)) * 60
-                + F.greatest(
-                    F.lit(0.0),
-                    F.lit(40.0)
-                    - (
-                        F.coalesce(F.col("total_cost_usd"), F.lit(0.0))
-                        / F.greatest(F.col("num_interactions").cast("double"), F.lit(1.0))
+            F.expr("""
+                LEAST(100.0,
+                    COALESCE(cache_hit_rate, 0.0) * 60
+                    + GREATEST(0.0,
+                        40.0 - (COALESCE(total_cost_usd, 0.0)
+                                / GREATEST(CAST(num_interactions AS DOUBLE), 1.0)) * 400
                     )
-                    * 400,
-                ),
-            ),
+                )
+            """),
         )
         .withColumn(
             "productivity_score",
-            F.least(
-                F.lit(100.0),
-                F.least(
-                    F.lit(50.0),
-                    (
-                        F.coalesce(F.col("num_tool_calls"), F.lit(0))
-                        / F.greatest(F.col("num_interactions").cast("double"), F.lit(1.0))
+            F.expr("""
+                LEAST(100.0,
+                    LEAST(50.0,
+                        COALESCE(num_tool_calls, 0)
+                        / GREATEST(CAST(num_interactions AS DOUBLE), 1.0) * 25
                     )
-                    * 25,
+                    + LEAST(50.0, CAST(num_interactions AS DOUBLE) * 10)
                 )
-                + F.least(F.lit(50.0), F.col("num_interactions").cast("double") * 10),
-            ),
+            """),
         )
         .withColumn(
             "quality_score",
-            F.least(
-                F.lit(100.0),
-                F.coalesce(F.col("tool_success_rate"), F.lit(1.0)) * 70
-                + F.greatest(
-                    F.lit(0.0),
-                    F.lit(30.0) - F.col("visible_error_count").cast("double") * 15,
-                ),
-            ),
+            F.expr("""
+                LEAST(100.0,
+                    COALESCE(tool_success_rate, 1.0) * 70
+                    + GREATEST(0.0, 30.0 - CAST(visible_error_count AS DOUBLE) * 15)
+                )
+            """),
         )
-        .withColumn("autonomy_score", F.coalesce(F.col("auto_accept_rate"), F.lit(0.0)) * 100)
+        .withColumn("autonomy_score", F.expr("COALESCE(auto_accept_rate, 0.0) * 100"))
         .withColumn(
             "engagement_score",
-            F.least(
-                F.lit(100.0),
-                F.least(
-                    F.lit(50.0),
-                    F.coalesce(F.col("session_duration_s"), F.lit(0.0)).cast("double") / 60 * 50,
+            F.expr("""
+                LEAST(100.0,
+                    LEAST(50.0, COALESCE(CAST(session_duration_s AS DOUBLE), 0.0) / 60 * 50)
+                    + LEAST(50.0, COALESCE(avg_prompt_length, 0.0))
                 )
-                + F.least(F.lit(50.0), F.coalesce(F.col("avg_prompt_length"), F.lit(0.0))),
-            ),
+            """),
         )
         .withColumn(
             "composite_score",
-            F.col("efficiency_score") * 0.20
-            + F.col("productivity_score") * 0.25
-            + F.col("quality_score") * 0.20
-            + F.col("autonomy_score") * 0.15
-            + F.col("engagement_score") * 0.20,
+            F.expr("""
+                efficiency_score * 0.20
+                + productivity_score * 0.25
+                + quality_score * 0.20
+                + autonomy_score * 0.15
+                + engagement_score * 0.20
+            """),
         )
     )
 

--- a/claude_otel_session_scorer/scorer.py
+++ b/claude_otel_session_scorer/scorer.py
@@ -149,15 +149,14 @@ def _build_prompt_udf(
 
 def run_scoring(
     spark: SparkSession,
-    target_catalog: str,
-    target_schema: str,
+    silver_schema: str,
     gold_schema: str,
     replay_char_budget: int = _REPLAY_CHAR_BUDGET,
     keep_interactions: int = _KEEP_INTERACTIONS,
 ) -> None:
     """Run the full incremental scoring pipeline: discover → replay → score → judge → merge."""
-    silver_summary = f"{target_catalog}.{target_schema}.session_summary"
-    silver_events = f"{target_catalog}.{target_schema}.session_events"
+    silver_summary = f"{silver_schema}.session_summary"
+    silver_events = f"{silver_schema}.session_events"
     gold_scores = f"{gold_schema}.session_scores"
 
     # Only score sessions whose last span ended before the start of today (UTC),
@@ -365,17 +364,20 @@ def run_scoring(
 def main() -> None:
     """Entry point: parse args, create Spark session, run scoring, stop Spark."""
     parser = ArgumentParser(description="Score Claude Code sessions using LLM-as-judge")
-    parser.add_argument("--target-catalog", required=True)
-    parser.add_argument("--target-schema", required=True)
+    parser.add_argument(
+        "--silver-schema",
+        required=True,
+        help="Full catalog.schema, e.g. prod.claude_silver",
+    )
     parser.add_argument(
         "--gold-schema",
         required=True,
         help="Full catalog.schema, e.g. prod.claude_gold",
     )
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
     spark = create_spark_session()
     try:
-        run_scoring(spark, args.target_catalog, args.target_schema, args.gold_schema)
+        run_scoring(spark, args.silver_schema, args.gold_schema)
     finally:
         if os.environ.get("DATABRICKS_RUNTIME_VERSION") is None:
             spark.stop()

--- a/claude_otel_session_scorer/silver_etl.py
+++ b/claude_otel_session_scorer/silver_etl.py
@@ -472,19 +472,17 @@ def _build_session_metrics(spark: SparkSession, bronze_metrics: str) -> DataFram
 
 def run_silver_etl(
     spark: SparkSession,
-    source_catalog: str,
-    source_schema: str,
-    target_catalog: str,
-    target_schema: str,
+    bronze_schema: str,
+    silver_schema: str,
 ) -> None:
-    bronze_traces = f"{source_catalog}.{source_schema}.claude_otel_traces"
-    bronze_metrics = f"{source_catalog}.{source_schema}.claude_otel_metrics"
-    bronze_logs = f"{source_catalog}.{source_schema}.claude_otel_logs"
-    silver_summary = f"{target_catalog}.{target_schema}.session_summary"
-    silver_events = f"{target_catalog}.{target_schema}.session_events"
-    silver_metrics = f"{target_catalog}.{target_schema}.session_metrics"
+    bronze_traces = f"{bronze_schema}.claude_otel_traces"
+    bronze_metrics = f"{bronze_schema}.claude_otel_metrics"
+    bronze_logs = f"{bronze_schema}.claude_otel_logs"
+    silver_summary = f"{silver_schema}.session_summary"
+    silver_events = f"{silver_schema}.session_events"
+    silver_metrics = f"{silver_schema}.session_metrics"
 
-    spark.sql(f"CREATE SCHEMA IF NOT EXISTS {target_catalog}.{target_schema}")
+    spark.sql(f"CREATE SCHEMA IF NOT EXISTS {silver_schema}")
 
     # session_summary — MERGE
     summary_df = _build_session_summary(spark, bronze_traces, bronze_metrics)
@@ -528,17 +526,21 @@ def main() -> None:
     parser = ArgumentParser(
         description="Silver ETL: transform bronze OTEL tables into silver session tables"
     )
-    parser.add_argument("--source-catalog", "-sc", required=True)
-    parser.add_argument("--source-schema", "-ss", required=True)
-    parser.add_argument("--target-catalog", "-tc", required=True)
-    parser.add_argument("--target-schema", "-ts", required=True)
-    args = parser.parse_args()
+    parser.add_argument(
+        "--bronze-schema",
+        required=True,
+        help="Full catalog.schema, e.g. prod.claude",
+    )
+    parser.add_argument(
+        "--silver-schema",
+        required=True,
+        help="Full catalog.schema, e.g. prod.claude_silver",
+    )
+    args, _ = parser.parse_known_args()
 
     spark = create_spark_session()
     try:
-        run_silver_etl(
-            spark, args.source_catalog, args.source_schema, args.target_catalog, args.target_schema
-        )
+        run_silver_etl(spark, args.bronze_schema, args.silver_schema)
     finally:
         spark.stop()
 

--- a/databricks.yml
+++ b/databricks.yml
@@ -50,6 +50,27 @@ resources:
             dependencies:
               - ./dist/*.whl
 
+    score_sessions_job:
+      name: "Claude OTEL Score Sessions Job"
+      tasks:
+        - task_key: "score_sessions_task"
+          python_wheel_task:
+            package_name: "claude_otel_session_scorer"
+            entry_point: "score_sessions"
+            named_parameters:
+              target-catalog: "your_catalog"
+              target-schema: "claude_silver"
+              gold-schema: "your_catalog.claude_gold"
+          environment_key: Default
+      queue:
+        enabled: true
+      environments:
+        - environment_key: Default
+          spec:
+            client: "5"
+            dependencies:
+              - ./dist/*.whl
+
 targets:
   dev:
     default: true

--- a/databricks.yml
+++ b/databricks.yml
@@ -28,10 +28,14 @@ resources:
             dependencies:
               - ./dist/*.whl
 
-    silver_etl_job:
-      name: "Claude OTEL Silver ETL Job"
+    otel_pipeline_job:
+      name: "Claude OTEL Pipeline"
+      schedule:
+        quartz_cron_expression: "0 0 1 * * ?"
+        timezone_id: "UTC"
+        pause_status: UNPAUSED
       tasks:
-        - task_key: "silver_etl_task"
+        - task_key: "silver_etl"
           python_wheel_task:
             package_name: "claude_otel_session_scorer"
             entry_point: "silver_etl"
@@ -41,19 +45,9 @@ resources:
               target-catalog: "your_catalog"
               target-schema: "claude_silver"
           environment_key: Default
-      queue:
-        enabled: true
-      environments:
-        - environment_key: Default
-          spec:
-            client: "5"
-            dependencies:
-              - ./dist/*.whl
-
-    score_sessions_job:
-      name: "Claude OTEL Score Sessions Job"
-      tasks:
-        - task_key: "score_sessions_task"
+        - task_key: "score_sessions"
+          depends_on:
+            - task_key: "silver_etl"
           python_wheel_task:
             package_name: "claude_otel_session_scorer"
             entry_point: "score_sessions"

--- a/databricks.yml
+++ b/databricks.yml
@@ -9,41 +9,27 @@ artifacts:
 
 resources:
   jobs:
-    claude_otel_session_scorer_job:
-      name: "Claude OTEL Session Scorer Job"
-      tasks:
-        - task_key: "main_task"
-          python_wheel_task:
-            package_name: "claude_otel_session_scorer"
-            entry_point: "main"
-            named_parameters:
-              table-name: "your_catalog.your_schema.your_table"
-          environment_key: Default
-      queue:
-        enabled: true
-      environments:
-        - environment_key: Default
-          spec:
-            client: "5"
-            dependencies:
-              - ./dist/*.whl
-
     otel_pipeline_job:
       name: "Claude OTEL Pipeline"
       schedule:
         quartz_cron_expression: "0 0 1 * * ?"
         timezone_id: "UTC"
         pause_status: UNPAUSED
+      parameters:
+        - name: bronze_schema
+          default: "tanner_fevm_catalog.claude"
+        - name: silver_schema
+          default: "tanner_fevm_catalog.claude_silver"
+        - name: gold_schema
+          default: "tanner_fevm_catalog.claude_gold"
       tasks:
         - task_key: "silver_etl"
           python_wheel_task:
             package_name: "claude_otel_session_scorer"
             entry_point: "silver_etl"
             named_parameters:
-              source-catalog: "your_catalog"
-              source-schema: "claude"
-              target-catalog: "your_catalog"
-              target-schema: "claude_silver"
+              bronze-schema: "{{job.parameters.bronze_schema}}"
+              silver-schema: "{{job.parameters.silver_schema}}"
           environment_key: Default
         - task_key: "score_sessions"
           depends_on:
@@ -52,9 +38,8 @@ resources:
             package_name: "claude_otel_session_scorer"
             entry_point: "score_sessions"
             named_parameters:
-              target-catalog: "your_catalog"
-              target-schema: "claude_silver"
-              gold-schema: "your_catalog.claude_gold"
+              silver-schema: "{{job.parameters.silver_schema}}"
+              gold-schema: "{{job.parameters.gold_schema}}"
           environment_key: Default
       queue:
         enabled: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry.scripts]
 claude_otel_session_scorer = "claude_otel_session_scorer.main:main"
 silver_etl = "claude_otel_session_scorer.silver_etl:main"
+score_sessions = "claude_otel_session_scorer.scorer:main"
 
 [tool.ruff]
 line-length = 100

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -1,0 +1,178 @@
+"""Tests for the scorer module."""
+
+from unittest.mock import MagicMock, patch
+
+from claude_otel_session_scorer.scorer import (
+    build_replay_text,
+    compress_interaction,
+    format_event_line,
+    main,
+    run_scoring,
+    split_into_interactions,
+)
+
+
+def _make_mock_spark(table_exists=False, new_session_count=1):
+    spark = MagicMock()
+    spark.catalog.tableExists.return_value = table_exists
+    df = MagicMock()
+    df.select.return_value = df
+    df.join.return_value = df
+    df.filter.return_value = df
+    df.groupBy.return_value = df
+    df.agg.return_value = df
+    df.withColumn.return_value = df
+    df.orderBy.return_value = df
+    df.count.return_value = new_session_count
+    spark.table.return_value = df
+    return spark
+
+
+def _sql_calls(spark):
+    return [c.args[0].strip() for c in spark.sql.call_args_list]
+
+
+class _Row:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+def test_format_event_line_defaults():
+    row = _Row(
+        event_ts="2025-01-01",
+        event_type="TOOL_USE",
+        detail_name="bash",
+        model="sonnet",
+        input_tokens=100,
+        output_tokens=50,
+        cost_usd=0.001,
+        error_category="",
+        content_preview="hello",
+    )
+    line = format_event_line(row)
+    assert "TOOL_USE" in line
+    assert "bash" in line
+    assert "0.0010" in line
+
+
+def test_split_into_interactions_empty():
+    assert split_into_interactions([]) == [[]]
+
+
+def test_split_into_interactions_splits_at_user_prompt():
+    rows = [
+        _Row(event_type="TOOL_USE"),
+        _Row(event_type="USER_PROMPT"),
+        _Row(event_type="TOOL_USE"),
+    ]
+    interactions = split_into_interactions(rows)
+    assert len(interactions) == 2
+    assert interactions[0][0].event_type == "TOOL_USE"
+    assert interactions[1][0].event_type == "USER_PROMPT"
+
+
+def test_compress_interaction_summary():
+    rows = [_Row(event_type="TOOL_USE", cost_usd=0.01, duration_ms=100)] * 3
+    result = compress_interaction(rows)
+    assert "compressed" in result
+    assert "3 events" in result
+    assert "TOOL_USE=3" in result
+
+
+def test_build_replay_text_truncates():
+    rows = [
+        _Row(
+            event_type="TOOL_USE",
+            event_ts="",
+            detail_name="",
+            model="",
+            input_tokens=0,
+            output_tokens=0,
+            cost_usd=0.0,
+            error_category="",
+            content_preview="x" * 200,
+        )
+    ]
+    text = build_replay_text(rows)
+    assert len(text) <= 30_000
+
+
+def test_build_replay_text_compresses_middle():
+    rows = []
+    for i in range(10):
+        rows.append(
+            _Row(
+                event_type="USER_PROMPT",
+                event_ts=str(i),
+                detail_name="",
+                model="",
+                input_tokens=0,
+                output_tokens=0,
+                cost_usd=0.0,
+                error_category="",
+                content_preview="",
+            )
+        )
+        rows.append(
+            _Row(
+                event_type="TOOL_USE",
+                event_ts=str(i),
+                detail_name="",
+                model="",
+                input_tokens=0,
+                output_tokens=0,
+                cost_usd=0.0,
+                error_category="",
+                content_preview="",
+            )
+        )
+    text = build_replay_text(rows)
+    assert "compressed" in text
+
+
+def test_early_exit_when_no_new_sessions():
+    spark = _make_mock_spark(table_exists=True, new_session_count=0)
+    run_scoring(spark, "cat", "silver", "cat.gold")
+    merge_calls = [s for s in _sql_calls(spark) if "MERGE INTO" in s]
+    assert len(merge_calls) == 0
+
+
+def test_creates_gold_table_if_not_exists():
+    spark = _make_mock_spark(table_exists=False, new_session_count=2)
+    run_scoring(spark, "cat", "silver", "cat.gold")
+    assert any("CREATE TABLE IF NOT EXISTS cat.gold.session_scores" in s for s in _sql_calls(spark))
+
+
+def test_merge_called_when_new_sessions():
+    spark = _make_mock_spark(table_exists=True, new_session_count=3)
+    run_scoring(spark, "cat", "silver", "cat.gold")
+    assert any("MERGE INTO cat.gold.session_scores" in s for s in _sql_calls(spark))
+
+
+def test_main_creates_spark_and_stops():
+    with (
+        patch("claude_otel_session_scorer.scorer.create_spark_session") as mock_create,
+        patch("claude_otel_session_scorer.scorer.run_scoring") as mock_run,
+    ):
+        mock_spark = MagicMock()
+        mock_create.return_value = mock_spark
+        import sys
+
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "score_sessions",
+                "--target-catalog",
+                "tc",
+                "--target-schema",
+                "ts",
+                "--gold-schema",
+                "tc.gold",
+            ],
+        ):
+            main()
+        mock_create.assert_called_once()
+        mock_run.assert_called_once_with(mock_spark, "tc", "ts", "tc.gold")
+        mock_spark.stop.assert_called_once()

--- a/tests/test_scorer.py
+++ b/tests/test_scorer.py
@@ -133,20 +133,20 @@ def test_build_replay_text_compresses_middle():
 
 def test_early_exit_when_no_new_sessions():
     spark = _make_mock_spark(table_exists=True, new_session_count=0)
-    run_scoring(spark, "cat", "silver", "cat.gold")
+    run_scoring(spark, "cat.silver", "cat.gold")
     merge_calls = [s for s in _sql_calls(spark) if "MERGE INTO" in s]
     assert len(merge_calls) == 0
 
 
 def test_creates_gold_table_if_not_exists():
     spark = _make_mock_spark(table_exists=False, new_session_count=2)
-    run_scoring(spark, "cat", "silver", "cat.gold")
+    run_scoring(spark, "cat.silver", "cat.gold")
     assert any("CREATE TABLE IF NOT EXISTS cat.gold.session_scores" in s for s in _sql_calls(spark))
 
 
 def test_merge_called_when_new_sessions():
     spark = _make_mock_spark(table_exists=True, new_session_count=3)
-    run_scoring(spark, "cat", "silver", "cat.gold")
+    run_scoring(spark, "cat.silver", "cat.gold")
     assert any("MERGE INTO cat.gold.session_scores" in s for s in _sql_calls(spark))
 
 
@@ -164,15 +164,13 @@ def test_main_creates_spark_and_stops():
             "argv",
             [
                 "score_sessions",
-                "--target-catalog",
-                "tc",
-                "--target-schema",
-                "ts",
+                "--silver-schema",
+                "tc.ts",
                 "--gold-schema",
                 "tc.gold",
             ],
         ):
             main()
         mock_create.assert_called_once()
-        mock_run.assert_called_once_with(mock_spark, "tc", "ts", "tc.gold")
+        mock_run.assert_called_once_with(mock_spark, "tc.ts", "tc.gold")
         mock_spark.stop.assert_called_once()

--- a/tests/test_silver_etl.py
+++ b/tests/test_silver_etl.py
@@ -21,13 +21,13 @@ def _sql_calls(spark):
 
 def test_run_silver_etl_calls_schema_create():
     spark = _make_mock_spark()
-    run_silver_etl(spark, "cat", "src", "cat", "tgt")
+    run_silver_etl(spark, "cat.src", "cat.tgt")
     assert any("CREATE SCHEMA IF NOT EXISTS cat.tgt" in s for s in _sql_calls(spark))
 
 
 def test_session_summary_merge():
     spark = _make_mock_spark()
-    run_silver_etl(spark, "cat", "src", "cat", "tgt")
+    run_silver_etl(spark, "cat.src", "cat.tgt")
     merge_calls = [s for s in _sql_calls(spark) if "MERGE INTO cat.tgt.session_summary" in s]
     assert len(merge_calls) == 1
     assert "WHEN MATCHED THEN UPDATE SET *" in merge_calls[0]
@@ -38,7 +38,7 @@ def test_session_events_delete_then_append():
     spark = _make_mock_spark()
     # Capture the DataFrame returned from the final unionByName chain so we can
     # check that .write.mode("append").saveAsTable(...) was called on it.
-    run_silver_etl(spark, "cat", "src", "cat", "tgt")
+    run_silver_etl(spark, "cat.src", "cat.tgt")
 
     delete_calls = [s for s in _sql_calls(spark) if "DELETE FROM cat.tgt.session_events" in s]
     assert len(delete_calls) == 1
@@ -54,7 +54,7 @@ def test_session_events_delete_then_append():
 
 def test_session_metrics_merge():
     spark = _make_mock_spark()
-    run_silver_etl(spark, "cat", "src", "cat", "tgt")
+    run_silver_etl(spark, "cat.src", "cat.tgt")
     merge_calls = [s for s in _sql_calls(spark) if "MERGE INTO cat.tgt.session_metrics" in s]
     assert len(merge_calls) == 1
     assert "WHEN MATCHED THEN UPDATE SET *" in merge_calls[0]
@@ -73,18 +73,14 @@ def test_main_creates_spark_and_stops():
             "sys.argv",
             [
                 "silver_etl",
-                "--source-catalog",
-                "sc",
-                "--source-schema",
-                "ss",
-                "--target-catalog",
-                "tc",
-                "--target-schema",
-                "ts",
+                "--bronze-schema",
+                "sc.ss",
+                "--silver-schema",
+                "tc.ts",
             ],
         ):
             main()
 
         mock_create.assert_called_once()
-        mock_run.assert_called_once_with(mock_spark, "sc", "ss", "tc", "ts")
+        mock_run.assert_called_once_with(mock_spark, "sc.ss", "tc.ts")
         mock_spark.stop.assert_called_once()


### PR DESCRIPTION
## Summary

Implements the incremental LLM-as-judge scoring pipeline that reads from the silver tables produced by the silver ETL job and writes scored sessions to a gold `session_scores` table.

Closes #6

## What's new

- **`claude_otel_session_scorer/scorer.py`** — `run_scoring(spark, target_catalog, target_schema, gold_schema)` implementing all five steps from the issue:
  1. **Incremental discovery** — left-anti join `session_summary` against existing `session_scores`; early return if nothing new (logs and exits cleanly without raising)
  2. **Replay text builder** — `format_event_line`, `split_into_interactions`, `compress_interaction`, `build_replay_text` with `REPLAY_CHAR_BUDGET = 30_000` and `KEEP_INTERACTIONS = 2`; keeps first/last interactions verbatim, compresses the middle, hard-truncates at the char budget
  3. **Metric scores (5 dims, pure PySpark)** — `efficiency_score`, `productivity_score`, `quality_score`, `autonomy_score`, `engagement_score`, `composite_score` computed via column expressions exactly as specified
  4. **LLM-as-judge** — `ai_query('databricks-claude-sonnet-4', full_prompt, responseFormat => ...)` via `F.expr`, parsed with `F.from_json` against the spec'd struct schema; prompt instructs the model not to penalize `INTERNAL_ERROR` / `BACKGROUND_ABORTED` / `USER_ABORTED` events
  5. **Delta MERGE** — `CREATE TABLE IF NOT EXISTS` with the explicit gold schema; `MERGE ON session_id` with `UPDATE SET *` / `INSERT *`; adds `scored_at` via `datetime.now(timezone.utc)` (no deprecated `utcnow()`)

- **`tests/test_scorer.py`** — covers helper functions (event line formatting, interaction splitting, replay compression and truncation), early-exit path when there are no new sessions, gold-table creation when missing, MERGE invocation when sessions are present, and the `main()` argparse / Spark lifecycle.

- **`pyproject.toml`** — registers the `score_sessions` console script pointing to `claude_otel_session_scorer.scorer:main`.

- **`databricks.yml`** — adds `score_sessions_job` mirroring the `silver_etl_job` pattern with `target-catalog`, `target-schema`, and `gold-schema` named parameters.

## Test plan

- [x] `poetry run pytest tests/test_scorer.py` passes locally
- [x] `poetry run ruff format --check .` and `poetry run ruff check .` pass
- [x] `databricks bundle validate` succeeds
- [x] Deploy and run `score_sessions_job` against a workspace with silver tables populated; confirm gold `session_scores` is created and incremental re-runs only score new sessions
- [x] Verify the run-as service principal has `CAN QUERY` on the `databricks-claude-sonnet-4` model serving endpoint before the first run
