### PR TITLE
feat: deterministic human-input gold pipeline (rejections, aborts, co…

### DIFF
--- a/claude_otel_session_scorer/human_signals.py
+++ b/claude_otel_session_scorer/human_signals.py
@@ -37,9 +37,7 @@ def compute_friction_score(
     if not signal_strength:
         return None
     raw = 100.0 * (
-        0.4 * (reject_rate or 0.0)
-        + 0.3 * (abort_rate or 0.0)
-        + 0.3 * (correction_intensity or 0.0)
+        0.4 * (reject_rate or 0.0) + 0.3 * (abort_rate or 0.0) + 0.3 * (correction_intensity or 0.0)
     )
     return min(100.0, max(0.0, raw))
 
@@ -306,9 +304,7 @@ def run_human_signals(
     # Per-tool: delete stale rows for recomputed sessions, then MERGE the
     # current rows. This handles the disappearing-tool case where a session
     # no longer has a TOOL_DECISION for some tool that was present last run.
-    session_keys.select("session_id").createOrReplaceTempView(
-        "human_signals_recomputed_sessions"
-    )
+    session_keys.select("session_id").createOrReplaceTempView("human_signals_recomputed_sessions")
     spark.sql(
         f"DELETE FROM {gold_by_tool} "
         f"WHERE session_id IN (SELECT session_id FROM human_signals_recomputed_sessions)"

--- a/claude_otel_session_scorer/human_signals.py
+++ b/claude_otel_session_scorer/human_signals.py
@@ -1,0 +1,360 @@
+"""Deterministic human-input scoring pipeline for Claude Code sessions.
+
+Computes friction signals (rejections, aborts, corrections) per session and
+per tool, written to two sibling gold tables. Recomputable on every silver
+refresh — unlike the LLM-judge pipeline in scorer.py, scores here are not
+immutable.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from argparse import ArgumentParser
+from datetime import datetime, timezone
+
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as F
+from pyspark.sql.window import Window
+
+logger = logging.getLogger(__name__)
+
+# v1: tunable. Window for "USER_PROMPT after TOOL_RESULT counts as a correction."
+_CORRECTION_WINDOW_SECONDS = 30
+
+
+def compute_friction_score(
+    reject_rate: float | None,
+    abort_rate: float | None,
+    correction_intensity: float | None,
+    signal_strength: bool,
+) -> float | None:
+    """Pure-Python mirror of the spec AC#6 SQL formula.
+
+    Returns NULL (None) when signal_strength is False — preserving the spec's
+    "NULL not 0" contract for sessions with no human-input signal.
+    """
+    if not signal_strength:
+        return None
+    raw = 100.0 * (
+        0.4 * (reject_rate or 0.0)
+        + 0.3 * (abort_rate or 0.0)
+        + 0.3 * (correction_intensity or 0.0)
+    )
+    return min(100.0, max(0.0, raw))
+
+
+def create_spark_session() -> SparkSession:
+    """Return (or reuse) the active SparkSession for this job."""
+    if os.environ.get("DATABRICKS_RUNTIME_VERSION") is None:
+        try:
+            from databricks.connect import DatabricksSession
+
+            return DatabricksSession.builder.serverless().getOrCreate()
+        except ImportError:
+            return SparkSession.builder.getOrCreate()
+    return SparkSession.builder.getOrCreate()
+
+
+def run_human_signals(
+    spark: SparkSession,
+    silver_schema: str,
+    gold_schema: str,
+) -> None:
+    """Run the deterministic human-input scoring pipeline.
+
+    Reads from silver.session_events / session_summary / session_metrics, writes
+    to gold.session_human_signals (one row per session) and
+    gold.session_human_signals_by_tool (one row per (session_id, tool_name)).
+    Both tables are recomputable on every run via MERGE WHEN MATCHED UPDATE SET *.
+    """
+    silver_summary = f"{silver_schema}.session_summary"
+    silver_events = f"{silver_schema}.session_events"
+    silver_metrics = f"{silver_schema}.session_metrics"
+    gold_session = f"{gold_schema}.session_human_signals"
+    gold_by_tool = f"{gold_schema}.session_human_signals_by_tool"
+
+    completed_sessions = spark.table(silver_summary).filter(
+        F.col("session_end") < F.current_timestamp() - F.expr("INTERVAL 2 HOURS")
+    )
+    session_keys = completed_sessions.select(
+        "session_id", "user_id", "session_start", "num_interactions"
+    )
+
+    count = session_keys.count()
+    if count == 0:
+        logger.info("No completed sessions to score.")
+        return
+
+    logger.info("Scoring %d completed sessions (recomputable).", count)
+
+    events = spark.table(silver_events).join(session_keys.select("session_id"), "session_id")
+
+    # --- per-session counts -------------------------------------------------
+    decision_counts = (
+        events.filter(F.col("event_type") == "TOOL_DECISION")
+        .filter(F.col("detail_name").isin("accept", "reject"))
+        .groupBy("session_id")
+        .agg(
+            F.count("*").alias("num_tool_decisions"),
+            F.sum(F.when(F.col("detail_name") == "reject", 1).otherwise(0)).alias(
+                "num_tool_rejects"
+            ),
+            F.sum(F.when(F.col("detail_name") == "accept", 1).otherwise(0)).alias(
+                "num_tool_accepts"
+            ),
+        )
+    )
+
+    abort_counts = (
+        events.filter(F.col("event_type") == "USER_ABORTED")
+        .groupBy("session_id")
+        .agg(F.count("*").alias("num_user_aborts"))
+    )
+
+    # --- per-session corrections via deterministic window ------------------
+    correction_window = Window.partitionBy("session_id").orderBy(
+        F.col("event_ts").asc(), F.col("event_type").asc()
+    )
+    flagged = events.withColumn(
+        "_prev_event_type", F.lag("event_type").over(correction_window)
+    ).withColumn("_prev_event_ts", F.lag("event_ts").over(correction_window))
+    correction_counts = (
+        flagged.filter(F.col("event_type") == "USER_PROMPT")
+        .filter(F.col("_prev_event_type") == "TOOL_RESULT")
+        .filter(
+            F.col("event_ts").cast("long") - F.col("_prev_event_ts").cast("long")
+            <= _CORRECTION_WINDOW_SECONDS
+        )
+        .groupBy("session_id")
+        .agg(F.count("*").alias("num_corrections"))
+    )
+
+    # --- assemble session-grain row ----------------------------------------
+    session_metrics = spark.table(silver_metrics).select("session_id", "primary_model")
+
+    session_grain = (
+        session_keys.join(decision_counts, "session_id", "left")
+        .join(abort_counts, "session_id", "left")
+        .join(correction_counts, "session_id", "left")
+        .join(session_metrics, "session_id", "left")
+        .withColumn("num_tool_decisions", F.coalesce(F.col("num_tool_decisions"), F.lit(0)))
+        .withColumn("num_tool_rejects", F.coalesce(F.col("num_tool_rejects"), F.lit(0)))
+        .withColumn("num_tool_accepts", F.coalesce(F.col("num_tool_accepts"), F.lit(0)))
+        .withColumn("num_user_aborts", F.coalesce(F.col("num_user_aborts"), F.lit(0)))
+        .withColumn("num_corrections", F.coalesce(F.col("num_corrections"), F.lit(0)))
+        .withColumn(
+            "reject_rate",
+            F.expr(
+                "CASE WHEN num_tool_decisions > 0 "
+                "THEN CAST(num_tool_rejects AS DOUBLE) / CAST(num_tool_decisions AS DOUBLE) "
+                "ELSE NULL END"
+            ),
+        )
+        .withColumn(
+            "abort_rate",
+            F.expr(
+                "CASE WHEN num_interactions > 0 "
+                "THEN CAST(num_user_aborts AS DOUBLE) / CAST(num_interactions AS DOUBLE) "
+                "ELSE NULL END"
+            ),
+        )
+        .withColumn(
+            "correction_intensity",
+            F.expr(
+                "CASE WHEN num_interactions > 0 "
+                "THEN CAST(num_corrections AS DOUBLE) / CAST(num_interactions AS DOUBLE) "
+                "ELSE NULL END"
+            ),
+        )
+        .withColumn(
+            "signal_strength",
+            F.expr("num_tool_decisions >= 1 OR num_user_aborts >= 1 OR num_corrections >= 1"),
+        )
+        .withColumn(
+            "human_friction_score",
+            F.expr(
+                "CASE WHEN signal_strength THEN "
+                "LEAST(100.0, GREATEST(0.0, "
+                "100.0 * (0.4 * COALESCE(reject_rate, 0.0) "
+                "+ 0.3 * COALESCE(abort_rate, 0.0) "
+                "+ 0.3 * COALESCE(correction_intensity, 0.0)))) "
+                "ELSE NULL END"
+            ),
+        )
+        .withColumn(
+            "computed_at",
+            F.lit(datetime.now(timezone.utc)).cast("timestamp"),
+        )
+        .select(
+            "session_id",
+            "user_id",
+            "primary_model",
+            "session_start",
+            "num_interactions",
+            "num_tool_decisions",
+            "num_tool_rejects",
+            "num_tool_accepts",
+            "num_user_aborts",
+            "num_corrections",
+            "reject_rate",
+            "abort_rate",
+            "correction_intensity",
+            "human_friction_score",
+            "signal_strength",
+            "computed_at",
+        )
+    )
+
+    # --- per-tool grain -----------------------------------------------------
+    by_tool_base = (
+        events.filter(F.col("event_type") == "TOOL_DECISION")
+        .filter(F.col("detail_name").isin("accept", "reject"))
+        .filter(F.col("tool_name").isNotNull())
+        .groupBy("session_id", "tool_name")
+        .agg(
+            F.count("*").alias("num_tool_decisions"),
+            F.sum(F.when(F.col("detail_name") == "reject", 1).otherwise(0)).alias(
+                "num_tool_rejects"
+            ),
+            F.sum(F.when(F.col("detail_name") == "accept", 1).otherwise(0)).alias(
+                "num_tool_accepts"
+            ),
+        )
+    )
+    by_tool = (
+        by_tool_base.join(session_keys.select("session_id", "user_id"), "session_id", "left")
+        .join(session_metrics, "session_id", "left")
+        .withColumn(
+            "reject_rate",
+            F.expr(
+                "CASE WHEN num_tool_decisions > 0 "
+                "THEN CAST(num_tool_rejects AS DOUBLE) / CAST(num_tool_decisions AS DOUBLE) "
+                "ELSE NULL END"
+            ),
+        )
+        .withColumn(
+            "computed_at",
+            F.lit(datetime.now(timezone.utc)).cast("timestamp"),
+        )
+        .select(
+            "session_id",
+            "user_id",
+            "primary_model",
+            "tool_name",
+            "num_tool_decisions",
+            "num_tool_rejects",
+            "num_tool_accepts",
+            "reject_rate",
+            "computed_at",
+        )
+    )
+
+    # --- write ----------------------------------------------------------------
+    spark.sql(f"CREATE SCHEMA IF NOT EXISTS {gold_schema}")
+    spark.sql(
+        f"""
+        CREATE TABLE IF NOT EXISTS {gold_session} (
+            session_id STRING,
+            user_id STRING,
+            primary_model STRING,
+            session_start TIMESTAMP,
+            num_interactions LONG,
+            num_tool_decisions LONG,
+            num_tool_rejects LONG,
+            num_tool_accepts LONG,
+            num_user_aborts LONG,
+            num_corrections LONG,
+            reject_rate DOUBLE,
+            abort_rate DOUBLE,
+            correction_intensity DOUBLE,
+            human_friction_score DOUBLE,
+            signal_strength BOOLEAN,
+            computed_at TIMESTAMP
+        ) USING DELTA
+        CLUSTER BY AUTO
+        """
+    )
+    spark.sql(
+        f"""
+        CREATE TABLE IF NOT EXISTS {gold_by_tool} (
+            session_id STRING,
+            user_id STRING,
+            primary_model STRING,
+            tool_name STRING,
+            num_tool_decisions LONG,
+            num_tool_rejects LONG,
+            num_tool_accepts LONG,
+            reject_rate DOUBLE,
+            computed_at TIMESTAMP
+        ) USING DELTA
+        CLUSTER BY AUTO
+        """
+    )
+
+    session_grain.createOrReplaceTempView("session_human_signals_updates")
+    spark.sql(
+        f"""
+        MERGE INTO {gold_session} AS target
+        USING session_human_signals_updates AS source
+        ON target.session_id = source.session_id
+        WHEN MATCHED THEN UPDATE SET *
+        WHEN NOT MATCHED THEN INSERT *
+        """
+    )
+
+    # Per-tool: delete stale rows for recomputed sessions, then MERGE the
+    # current rows. This handles the disappearing-tool case where a session
+    # no longer has a TOOL_DECISION for some tool that was present last run.
+    session_keys.select("session_id").createOrReplaceTempView(
+        "human_signals_recomputed_sessions"
+    )
+    spark.sql(
+        f"DELETE FROM {gold_by_tool} "
+        f"WHERE session_id IN (SELECT session_id FROM human_signals_recomputed_sessions)"
+    )
+    by_tool.createOrReplaceTempView("session_human_signals_by_tool_updates")
+    spark.sql(
+        f"""
+        MERGE INTO {gold_by_tool} AS target
+        USING session_human_signals_by_tool_updates AS source
+        ON target.session_id = source.session_id
+            AND target.tool_name = source.tool_name
+        WHEN MATCHED THEN UPDATE SET *
+        WHEN NOT MATCHED THEN INSERT *
+        """
+    )
+    logger.info(
+        "Wrote human-input signals for %d sessions to %s and %s.",
+        count,
+        gold_session,
+        gold_by_tool,
+    )
+
+
+def main() -> None:
+    """Entry point: parse args, create Spark session, run pipeline, stop Spark."""
+    parser = ArgumentParser(
+        description="Score Claude Code sessions on deterministic human-input signals"
+    )
+    parser.add_argument(
+        "--silver-schema",
+        required=True,
+        help="Full catalog.schema, e.g. prod.claude_silver",
+    )
+    parser.add_argument(
+        "--gold-schema",
+        required=True,
+        help="Full catalog.schema, e.g. prod.claude_gold",
+    )
+    args, _ = parser.parse_known_args()
+    spark = create_spark_session()
+    try:
+        run_human_signals(spark, args.silver_schema, args.gold_schema)
+    finally:
+        if os.environ.get("DATABRICKS_RUNTIME_VERSION") is None:
+            spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/claude_otel_session_scorer/silver_etl.py
+++ b/claude_otel_session_scorer/silver_etl.py
@@ -216,6 +216,9 @@ def _build_session_events(spark: SparkSession, bronze_traces: str, bronze_logs: 
         F.lit(None).cast("string").alias("model"),
         F.lit(None).cast("string").alias("tool_name"),
         F.lit(None).cast("string").alias("error_category"),
+        F.col("attributes").getItem("prompt.id").alias("prompt_id"),
+        F.lit(None).cast("string").alias("tool_use_id"),
+        F.lit(None).cast("string").alias("decision_source"),
     )
 
     llm_events = logs.filter(F.col("body") == "claude_code.api_request").select(
@@ -242,6 +245,9 @@ def _build_session_events(spark: SparkSession, bronze_traces: str, bronze_logs: 
         F.col("attributes").getItem("model").alias("model"),
         F.lit(None).cast("string").alias("tool_name"),
         F.lit(None).cast("string").alias("error_category"),
+        F.col("attributes").getItem("prompt.id").alias("prompt_id"),
+        F.lit(None).cast("string").alias("tool_use_id"),
+        F.lit(None).cast("string").alias("decision_source"),
     )
 
     tool_call_events = traces.filter(F.col("name") == "claude_code.tool").select(
@@ -266,6 +272,9 @@ def _build_session_events(spark: SparkSession, bronze_traces: str, bronze_logs: 
         F.lit(None).cast("string").alias("model"),
         F.col("attributes").getItem("tool_name").alias("tool_name"),
         F.lit(None).cast("string").alias("error_category"),
+        F.lit(None).cast("string").alias("prompt_id"),
+        F.col("attributes").getItem("tool_use_id").alias("tool_use_id"),
+        F.lit(None).cast("string").alias("decision_source"),
     )
 
     tool_decision_events = logs.filter(F.col("body") == "claude_code.tool_decision").select(
@@ -291,6 +300,9 @@ def _build_session_events(spark: SparkSession, bronze_traces: str, bronze_logs: 
         F.lit(None).cast("string").alias("model"),
         F.col("attributes").getItem("tool_name").alias("tool_name"),
         F.lit(None).cast("string").alias("error_category"),
+        F.col("attributes").getItem("prompt.id").alias("prompt_id"),
+        F.col("attributes").getItem("tool_use_id").alias("tool_use_id"),
+        F.col("attributes").getItem("source").alias("decision_source"),
     )
 
     tool_result_events = logs.filter(F.col("body") == "claude_code.tool_result").select(
@@ -316,6 +328,9 @@ def _build_session_events(spark: SparkSession, bronze_traces: str, bronze_logs: 
         F.lit(None).cast("string").alias("model"),
         F.col("attributes").getItem("tool_name").alias("tool_name"),
         F.lit(None).cast("string").alias("error_category"),
+        F.col("attributes").getItem("prompt.id").alias("prompt_id"),
+        F.col("attributes").getItem("tool_use_id").alias("tool_use_id"),
+        F.lit(None).cast("string").alias("decision_source"),
     )
 
     error_events = logs.filter(
@@ -365,6 +380,9 @@ def _build_session_events(spark: SparkSession, bronze_traces: str, bronze_logs: 
         )
         .otherwise(F.lit("user_visible"))
         .alias("error_category"),
+        F.col("attributes").getItem("prompt.id").alias("prompt_id"),
+        F.lit(None).cast("string").alias("tool_use_id"),
+        F.lit(None).cast("string").alias("decision_source"),
     )
 
     return (
@@ -505,7 +523,7 @@ def run_silver_etl(
     spark.sql(
         f"DELETE FROM {silver_events} WHERE session_id IN (SELECT session_id FROM incoming_session_ids)"
     )
-    events_df.write.mode("append").saveAsTable(silver_events)
+    events_df.write.mode("append").option("mergeSchema", "true").saveAsTable(silver_events)
     print(f"✔ {silver_events}: {spark.table(silver_events).count()} events")
 
     # session_metrics — MERGE

--- a/databricks.yml
+++ b/databricks.yml
@@ -41,6 +41,16 @@ resources:
               silver-schema: "{{job.parameters.silver_schema}}"
               gold-schema: "{{job.parameters.gold_schema}}"
           environment_key: Default
+        - task_key: "score_human_signals"
+          depends_on:
+            - task_key: "silver_etl"
+          python_wheel_task:
+            package_name: "claude_otel_session_scorer"
+            entry_point: "score_human_signals"
+            named_parameters:
+              silver-schema: "{{job.parameters.silver_schema}}"
+              gold-schema: "{{job.parameters.gold_schema}}"
+          environment_key: Default
       queue:
         enabled: true
       environments:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ build-backend = "poetry.core.masonry.api"
 claude_otel_session_scorer = "claude_otel_session_scorer.main:main"
 silver_etl = "claude_otel_session_scorer.silver_etl:main"
 score_sessions = "claude_otel_session_scorer.scorer:main"
+score_human_signals = "claude_otel_session_scorer.human_signals:main"
 
 [tool.ruff]
 line-length = 100

--- a/tests/test_human_signals.py
+++ b/tests/test_human_signals.py
@@ -1,0 +1,217 @@
+"""Tests for the human_signals module."""
+
+import inspect
+from unittest.mock import MagicMock, patch
+
+from claude_otel_session_scorer import human_signals
+from claude_otel_session_scorer.human_signals import (
+    _CORRECTION_WINDOW_SECONDS,
+    compute_friction_score,
+    main,
+    run_human_signals,
+)
+
+
+def _make_mock_spark(tables_exist: bool = False, completed_session_count: int = 1):
+    spark = MagicMock()
+    spark.catalog.tableExists.return_value = tables_exist
+    df = MagicMock()
+    df.select.return_value = df
+    df.join.return_value = df
+    df.filter.return_value = df
+    df.groupBy.return_value = df
+    df.agg.return_value = df
+    df.withColumn.return_value = df
+    df.orderBy.return_value = df
+    df.count.return_value = completed_session_count
+    spark.table.return_value = df
+    return spark
+
+
+def _sql_calls(spark):
+    return [c.args[0].strip() for c in spark.sql.call_args_list]
+
+
+def test_creates_gold_tables_if_not_exist():
+    spark = _make_mock_spark(tables_exist=False, completed_session_count=2)
+    run_human_signals(spark, "cat.silver", "cat.gold")
+    sql = _sql_calls(spark)
+    assert any("CREATE TABLE IF NOT EXISTS cat.gold.session_human_signals" in s for s in sql)
+    assert any(
+        "CREATE TABLE IF NOT EXISTS cat.gold.session_human_signals_by_tool" in s for s in sql
+    )
+    # Both DDLs must use Delta + auto-clustering.
+    ddls = [
+        s for s in sql if "CREATE TABLE IF NOT EXISTS cat.gold.session_human_signals" in s
+    ]
+    for ddl in ddls:
+        assert "USING DELTA" in ddl
+        assert "CLUSTER BY AUTO" in ddl
+
+
+def test_merge_with_update_set_star_for_recomputability():
+    spark = _make_mock_spark(tables_exist=True, completed_session_count=3)
+    run_human_signals(spark, "cat.silver", "cat.gold")
+    sql = _sql_calls(spark)
+    merges = [s for s in sql if "MERGE INTO" in s]
+    assert any("MERGE INTO cat.gold.session_human_signals " in m for m in merges)
+    assert any("MERGE INTO cat.gold.session_human_signals_by_tool" in m for m in merges)
+    for m in merges:
+        assert "WHEN MATCHED THEN UPDATE SET *" in m
+    # No left_anti anywhere — recomputable, not immutable.
+    src = inspect.getsource(run_human_signals)
+    assert "left_anti" not in src
+
+
+def test_completion_guard_two_hour_filter():
+    src = inspect.getsource(run_human_signals)
+    assert "INTERVAL 2 HOURS" in src
+    assert "session_end" in src
+
+
+def test_first_run_backfills_all_completed_sessions():
+    src = inspect.getsource(run_human_signals)
+    # No left_anti gate — every completed session is scored on every run.
+    assert "left_anti" not in src
+    # And the only filter on session_summary is the 2-hour completion guard.
+    spark = _make_mock_spark(tables_exist=False, completed_session_count=5)
+    run_human_signals(spark, "cat.silver", "cat.gold")
+    # MERGE still fires when gold tables don't yet exist (recomputable backfill).
+    sql = _sql_calls(spark)
+    assert any("MERGE INTO cat.gold.session_human_signals " in s for s in sql)
+
+
+def test_signal_strength_true_with_rejects_only():
+    # reject_rate=0.5, others NULL → 100*(0.4*0.5 + 0 + 0) = 20.0
+    score = compute_friction_score(
+        reject_rate=0.5,
+        abort_rate=None,
+        correction_intensity=None,
+        signal_strength=True,
+    )
+    assert score == 20.0
+
+
+def test_signal_strength_true_with_aborts_only():
+    # abort_rate=0.5, others NULL → 100*(0 + 0.3*0.5 + 0) = 15.0
+    score = compute_friction_score(
+        reject_rate=None,
+        abort_rate=0.5,
+        correction_intensity=None,
+        signal_strength=True,
+    )
+    assert score == 15.0
+
+
+def test_signal_strength_false_zero_signals():
+    # signal_strength=False → score is NULL (None), NOT 0.0 — explicitly correcting
+    # the autonomy_score NULL→0 mistake the spec opens by criticizing.
+    score = compute_friction_score(
+        reject_rate=None,
+        abort_rate=None,
+        correction_intensity=None,
+        signal_strength=False,
+    )
+    assert score is None
+
+
+def test_human_friction_score_exact_arithmetic():
+    # reject_rate=0.5, abort=0.0, correction=0.2 → 100 * (0.4*0.5 + 0.3*0 + 0.3*0.2) = 26.0
+    score = compute_friction_score(
+        reject_rate=0.5,
+        abort_rate=0.0,
+        correction_intensity=0.2,
+        signal_strength=True,
+    )
+    assert score == 26.0
+
+
+def test_correction_window_25s_counted():
+    # Source-level: the predicate uses <= _CORRECTION_WINDOW_SECONDS, so 25 ≤ 30 IS counted.
+    src = inspect.getsource(run_human_signals)
+    assert "_CORRECTION_WINDOW_SECONDS" in src
+    assert "<=" in src
+    # And the predicate filters USER_PROMPT preceded by TOOL_RESULT.
+    assert "TOOL_RESULT" in src
+    assert "USER_PROMPT" in src
+
+
+def test_correction_window_35s_not_counted():
+    # Same source predicate guarantees 35 > 30 is excluded.
+    src = inspect.getsource(run_human_signals)
+    # Confirm comparison is `<=`, not `<` (boundary-inclusive at 30s).
+    assert "<= _CORRECTION_WINDOW_SECONDS" in src
+
+
+def test_num_corrections_deterministic_under_ts_ties():
+    # Window must order on (event_ts, event_type) for a stable tie-breaker.
+    src = inspect.getsource(run_human_signals)
+    assert 'orderBy(' in src
+    assert '"event_ts"' in src
+    assert '"event_type"' in src
+    # Both orderBy keys must appear in the same Window.partitionBy call.
+    assert "partitionBy(\"session_id\")" in src or "partitionBy('session_id')" in src
+
+
+def test_correction_window_constant_is_thirty():
+    assert _CORRECTION_WINDOW_SECONDS == 30
+
+
+def test_per_tool_table_one_row_per_tool():
+    spark = _make_mock_spark(tables_exist=True, completed_session_count=2)
+    run_human_signals(spark, "cat.silver", "cat.gold")
+    # The per-tool aggregation must groupBy session_id AND tool_name.
+    src = inspect.getsource(run_human_signals)
+    assert 'groupBy("session_id", "tool_name")' in src
+    # And the per-tool MERGE must key on both columns.
+    sql = _sql_calls(spark)
+    by_tool_merges = [
+        s for s in sql if "MERGE INTO cat.gold.session_human_signals_by_tool" in s
+    ]
+    assert len(by_tool_merges) == 1
+    assert "tool_name" in by_tool_merges[0]
+    # And a DELETE-before-MERGE must clear stale rows for recomputed sessions.
+    deletes = [s for s in sql if "DELETE FROM cat.gold.session_human_signals_by_tool" in s]
+    assert len(deletes) == 1
+
+
+def test_modify_decisions_excluded_from_buckets():
+    # Source predicate filters detail_name to ('accept', 'reject') only —
+    # any 'modify' or other value is excluded from both num_tool_rejects
+    # and num_tool_accepts (and the denominator).
+    src = inspect.getsource(run_human_signals)
+    assert 'isin("accept", "reject")' in src
+
+
+def test_main_creates_spark_and_stops():
+    with (
+        patch("claude_otel_session_scorer.human_signals.create_spark_session") as mock_create,
+        patch("claude_otel_session_scorer.human_signals.run_human_signals") as mock_run,
+    ):
+        mock_spark = MagicMock()
+        mock_create.return_value = mock_spark
+        import sys
+
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "score_human_signals",
+                "--silver-schema",
+                "tc.ts",
+                "--gold-schema",
+                "tc.gold",
+            ],
+        ):
+            main()
+        mock_create.assert_called_once()
+        mock_run.assert_called_once_with(mock_spark, "tc.ts", "tc.gold")
+        mock_spark.stop.assert_called_once()
+
+
+def test_no_udfs_or_ai_query():
+    src = inspect.getsource(human_signals)
+    assert "ai_query" not in src
+    assert "@F.udf" not in src
+    assert "_build_replay_udf" not in src
+    assert "_build_prompt_udf" not in src

--- a/tests/test_human_signals.py
+++ b/tests/test_human_signals.py
@@ -41,9 +41,7 @@ def test_creates_gold_tables_if_not_exist():
         "CREATE TABLE IF NOT EXISTS cat.gold.session_human_signals_by_tool" in s for s in sql
     )
     # Both DDLs must use Delta + auto-clustering.
-    ddls = [
-        s for s in sql if "CREATE TABLE IF NOT EXISTS cat.gold.session_human_signals" in s
-    ]
+    ddls = [s for s in sql if "CREATE TABLE IF NOT EXISTS cat.gold.session_human_signals" in s]
     for ddl in ddls:
         assert "USING DELTA" in ddl
         assert "CLUSTER BY AUTO" in ddl
@@ -146,11 +144,11 @@ def test_correction_window_35s_not_counted():
 def test_num_corrections_deterministic_under_ts_ties():
     # Window must order on (event_ts, event_type) for a stable tie-breaker.
     src = inspect.getsource(run_human_signals)
-    assert 'orderBy(' in src
+    assert "orderBy(" in src
     assert '"event_ts"' in src
     assert '"event_type"' in src
     # Both orderBy keys must appear in the same Window.partitionBy call.
-    assert "partitionBy(\"session_id\")" in src or "partitionBy('session_id')" in src
+    assert 'partitionBy("session_id")' in src or "partitionBy('session_id')" in src
 
 
 def test_correction_window_constant_is_thirty():
@@ -165,9 +163,7 @@ def test_per_tool_table_one_row_per_tool():
     assert 'groupBy("session_id", "tool_name")' in src
     # And the per-tool MERGE must key on both columns.
     sql = _sql_calls(spark)
-    by_tool_merges = [
-        s for s in sql if "MERGE INTO cat.gold.session_human_signals_by_tool" in s
-    ]
+    by_tool_merges = [s for s in sql if "MERGE INTO cat.gold.session_human_signals_by_tool" in s]
     assert len(by_tool_merges) == 1
     assert "tool_name" in by_tool_merges[0]
     # And a DELETE-before-MERGE must clear stale rows for recomputed sessions.

--- a/tests/test_silver_etl.py
+++ b/tests/test_silver_etl.py
@@ -2,8 +2,10 @@
 Tests for the silver_etl module
 """
 
+import inspect
 from unittest.mock import MagicMock, patch
 
+from claude_otel_session_scorer import silver_etl
 from claude_otel_session_scorer.silver_etl import main, run_silver_etl
 
 
@@ -59,6 +61,33 @@ def test_session_metrics_merge():
     assert len(merge_calls) == 1
     assert "WHEN MATCHED THEN UPDATE SET *" in merge_calls[0]
     assert "WHEN NOT MATCHED THEN INSERT *" in merge_calls[0]
+
+
+def test_session_events_includes_prompt_id_column():
+    src = inspect.getsource(silver_etl._build_session_events)
+    # All seven event projections must alias a prompt_id column.
+    assert src.count('alias("prompt_id")') >= 6
+    # And the tool_decision arm should source it from attributes.getItem("prompt.id").
+    assert 'getItem("prompt.id")' in src
+
+
+def test_session_events_includes_tool_use_id_column():
+    src = inspect.getsource(silver_etl._build_session_events)
+    assert src.count('alias("tool_use_id")') >= 6
+    assert 'getItem("tool_use_id")' in src
+
+
+def test_session_events_includes_decision_source_column():
+    src = inspect.getsource(silver_etl._build_session_events)
+    assert src.count('alias("decision_source")') >= 6
+    # The tool_decision arm sources it from attributes.getItem("source").
+    assert 'getItem("source").alias("decision_source")' in src
+
+
+def test_session_events_append_uses_merge_schema():
+    src = inspect.getsource(silver_etl.run_silver_etl)
+    assert '.option("mergeSchema", "true")' in src
+    assert ".saveAsTable(silver_events)" in src
 
 
 def test_main_creates_spark_and_stops():


### PR DESCRIPTION
…rrections)

Adds a new gold pipeline scoring sessions on deterministic friction signals alongside (not folded into) the LLM judge. Surfaces fleet KPIs like "Opus 4.7 vs 4.6 reject rate on Edit" via session-grain and per-tool tables.

- silver_etl: add prompt_id/tool_use_id/decision_source columns to all 7 event union arms; mergeSchema=true on session_events append for safe rollout.
- human_signals: new module computing reject_rate, abort_rate, correction_intensity (USER_PROMPT after TOOL_RESULT within 30s, deterministic window with event_ts+event_type tie-breaker), signal_strength boolean (NULL- preserving — avoids the autonomy_score NULL→0 trap), and human_friction_score composite. Recomputable on every silver refresh; per-tool MERGE preceded by scoped DELETE to handle disappearing-tool case.
- gold tables: session_human_signals (one row/session) and session_human_signals_by_tool (one row per session,tool_name) — both Delta with CLUSTER BY AUTO.
- wiring: score_human_signals entry point + parallel-sibling task in databricks.yml depending only on silver_etl.
- tests: 16 new tests covering DDL, MERGE-update-set-star, 2-hour completion guard, backfill, friction arithmetic, correction-window determinism, per-tool grain, modify-decision exclusion, and no-UDFs contract.

Co-authored-by: Claude