### PR TITLE
fix: use F.current_timestamp() for scored_at/computed_at

### DIFF
--- a/claude_otel_session_scorer/human_signals.py
+++ b/claude_otel_session_scorer/human_signals.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 import logging
 import os
 from argparse import ArgumentParser
-from datetime import datetime, timezone
-
 from pyspark.sql import SparkSession
 from pyspark.sql import functions as F
 from pyspark.sql.window import Window
@@ -182,7 +180,7 @@ def run_human_signals(
         )
         .withColumn(
             "computed_at",
-            F.lit(datetime.now(timezone.utc)).cast("timestamp"),
+            F.current_timestamp(),
         )
         .select(
             "session_id",
@@ -233,7 +231,7 @@ def run_human_signals(
         )
         .withColumn(
             "computed_at",
-            F.lit(datetime.now(timezone.utc)).cast("timestamp"),
+            F.current_timestamp(),
         )
         .select(
             "session_id",

--- a/claude_otel_session_scorer/scorer.py
+++ b/claude_otel_session_scorer/scorer.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import logging
 import os
 from argparse import ArgumentParser
-from datetime import datetime, timezone
-
 from pyspark.sql import SparkSession
 from pyspark.sql import functions as F
 from pyspark.sql.types import StringType
@@ -315,7 +313,7 @@ def run_scoring(
         F.col("judgment.overall_score").alias("llm_overall_score"),
         F.col("judgment.summary").alias("llm_summary"),
         F.col("judgment.recommendations").alias("llm_recommendations"),
-        F.lit(datetime.now(timezone.utc)).cast("timestamp").alias("scored_at"),
+        F.current_timestamp().alias("scored_at"),
     )
     gold_df = gold_df.filter(F.col("llm_overall_score").isNotNull())
 


### PR DESCRIPTION
Fixes #12.

`F.lit(datetime.now(timezone.utc)).cast("timestamp")` is evaluated once at driver plan-build time — on a long-running job every row gets the same stale timestamp. Replaced with `F.current_timestamp()`, which evaluates at worker execution time. Also removed the no-op `.cast("timestamp")` that followed it.