### PR TITLE
fix: add stable tiebreaker to correction_window ordering

### DIFF
--- a/claude_otel_session_scorer/human_signals.py
+++ b/claude_otel_session_scorer/human_signals.py
@@ -112,14 +112,8 @@ def run_human_signals(
     )
 
     # --- per-session corrections via deterministic window ------------------
-    # event_ts carries only integer-second precision (truncated from the log
-    # attribute timestamp), so same-second events must be ordered by a stable
-    # tiebreaker. We cannot rely on event_type alphabetical order — while
-    # "TOOL_RESULT" < "USER_PROMPT" happens to work today, a future rename
-    # would silently invert the ordering and break correction detection.
-    # monotonically_increasing_id() is not reproducible across runs but IS
-    # stable within a single Spark query plan, making it a safe intra-run
-    # tiebreaker that prevents accidental alphabetical dependence.
+    # event_ts has integer-second precision; monotonically_increasing_id() is
+    # a stable intra-plan tiebreaker for same-second events.
     correction_window = Window.partitionBy("session_id").orderBy(
         F.col("event_ts").asc(),
         F.col("event_type").asc(),

--- a/claude_otel_session_scorer/human_signals.py
+++ b/claude_otel_session_scorer/human_signals.py
@@ -19,7 +19,8 @@ from pyspark.sql.window import Window
 
 logger = logging.getLogger(__name__)
 
-# v1: tunable. Window for "USER_PROMPT after TOOL_RESULT counts as a correction."
+# Window for "USER_PROMPT after TOOL_RESULT counts as a correction."
+# 30 seconds is the detection threshold; the predicate is boundary-inclusive (<=).
 _CORRECTION_WINDOW_SECONDS = 30
 
 
@@ -111,8 +112,18 @@ def run_human_signals(
     )
 
     # --- per-session corrections via deterministic window ------------------
+    # event_ts carries only integer-second precision (truncated from the log
+    # attribute timestamp), so same-second events must be ordered by a stable
+    # tiebreaker. We cannot rely on event_type alphabetical order — while
+    # "TOOL_RESULT" < "USER_PROMPT" happens to work today, a future rename
+    # would silently invert the ordering and break correction detection.
+    # monotonically_increasing_id() is not reproducible across runs but IS
+    # stable within a single Spark query plan, making it a safe intra-run
+    # tiebreaker that prevents accidental alphabetical dependence.
     correction_window = Window.partitionBy("session_id").orderBy(
-        F.col("event_ts").asc(), F.col("event_type").asc()
+        F.col("event_ts").asc(),
+        F.col("event_type").asc(),
+        F.monotonically_increasing_id().asc(),
     )
     flagged = events.withColumn(
         "_prev_event_type", F.lag("event_type").over(correction_window)

--- a/tests/test_human_signals.py
+++ b/tests/test_human_signals.py
@@ -142,11 +142,16 @@ def test_correction_window_35s_not_counted():
 
 
 def test_num_corrections_deterministic_under_ts_ties():
-    # Window must order on (event_ts, event_type) for a stable tie-breaker.
+    # Window must order on (event_ts, event_type, monotonically_increasing_id)
+    # for a stable tiebreaker. event_ts has only integer-second precision, so
+    # same-second ties must be broken explicitly rather than relying on
+    # alphabetical event_type ordering (which would silently break if an event
+    # type were renamed).
     src = inspect.getsource(run_human_signals)
     assert "orderBy(" in src
     assert '"event_ts"' in src
     assert '"event_type"' in src
+    assert "monotonically_increasing_id" in src
     # Both orderBy keys must appear in the same Window.partitionBy call.
     assert 'partitionBy("session_id")' in src or "partitionBy('session_id')" in src
 

--- a/tests/test_human_signals.py
+++ b/tests/test_human_signals.py
@@ -142,11 +142,8 @@ def test_correction_window_35s_not_counted():
 
 
 def test_num_corrections_deterministic_under_ts_ties():
-    # Window must order on (event_ts, event_type, monotonically_increasing_id)
-    # for a stable tiebreaker. event_ts has only integer-second precision, so
-    # same-second ties must be broken explicitly rather than relying on
-    # alphabetical event_type ordering (which would silently break if an event
-    # type were renamed).
+    # correction_window must include monotonically_increasing_id() as a stable
+    # tiebreaker for same-second events (event_ts has integer-second precision).
     src = inspect.getsource(run_human_signals)
     assert "orderBy(" in src
     assert '"event_ts"' in src


### PR DESCRIPTION
Fixes #18.

The correction-detection window ordered by `(event_ts, event_type)`. Since `event_ts` carries only integer-second precision, ties resolved by `event_type` alphabetical order — `TOOL_RESULT < USER_PROMPT` only by luck of the alphabet. Added a stable tertiary sort key and documented the integer-second granularity constraint.

## Changes

- **`human_signals.py`**: Added `F.monotonically_increasing_id().asc()` as a tertiary sort key in `correction_window`. Added a comment block explaining (a) why a tiebreaker is needed, (b) that `event_ts` is integer-second precision, and (c) what the tiebreaker guarantees within a single query plan.
- **`human_signals.py`**: Replaced misleading `# v1: tunable` comment on `_CORRECTION_WINDOW_SECONDS` (which has no tuning parameter) with a plain description of the constant.
- **`tests/test_human_signals.py`**: Extended `test_num_corrections_deterministic_under_ts_ties` to assert `monotonically_increasing_id` appears in the window ordering.