### PR TITLE
refactor: consolidate create_spark_session() into shared _spark module

### DIFF
--- a/claude_otel_session_scorer/_spark.py
+++ b/claude_otel_session_scorer/_spark.py
@@ -1,0 +1,26 @@
+"""Shared Spark session factory for all claude_otel_session_scorer pipelines."""
+
+from __future__ import annotations
+
+import os
+
+
+def create_spark_session():
+    """Return (or reuse) the active SparkSession for this job.
+
+    When running inside a Databricks cluster (DATABRICKS_RUNTIME_VERSION is set)
+    the ambient session is returned directly.  Outside a cluster, Databricks
+    Connect (serverless) is tried first; if it is not installed a standard local
+    SparkSession is returned with a clear warning.
+    """
+    from pyspark.sql import SparkSession
+
+    if os.environ.get("DATABRICKS_RUNTIME_VERSION") is None:
+        try:
+            from databricks.connect import DatabricksSession
+
+            return DatabricksSession.builder.serverless().getOrCreate()
+        except ImportError:
+            print("Databricks Connect not available. Falling back to standard Spark session.")
+            return SparkSession.builder.getOrCreate()
+    return SparkSession.builder.getOrCreate()

--- a/claude_otel_session_scorer/human_signals.py
+++ b/claude_otel_session_scorer/human_signals.py
@@ -15,6 +15,8 @@ from pyspark.sql import SparkSession
 from pyspark.sql import functions as F
 from pyspark.sql.window import Window
 
+from claude_otel_session_scorer._spark import create_spark_session
+
 logger = logging.getLogger(__name__)
 
 # Window for "USER_PROMPT after TOOL_RESULT counts as a correction."
@@ -39,18 +41,6 @@ def compute_friction_score(
         0.4 * (reject_rate or 0.0) + 0.3 * (abort_rate or 0.0) + 0.3 * (correction_intensity or 0.0)
     )
     return min(100.0, max(0.0, raw))
-
-
-def create_spark_session() -> SparkSession:
-    """Return (or reuse) the active SparkSession for this job."""
-    if os.environ.get("DATABRICKS_RUNTIME_VERSION") is None:
-        try:
-            from databricks.connect import DatabricksSession
-
-            return DatabricksSession.builder.serverless().getOrCreate()
-        except ImportError:
-            return SparkSession.builder.getOrCreate()
-    return SparkSession.builder.getOrCreate()
 
 
 def run_human_signals(

--- a/claude_otel_session_scorer/scorer.py
+++ b/claude_otel_session_scorer/scorer.py
@@ -9,6 +9,8 @@ from pyspark.sql import SparkSession
 from pyspark.sql import functions as F
 from pyspark.sql.types import StringType
 
+from claude_otel_session_scorer._spark import create_spark_session
+
 logger = logging.getLogger(__name__)
 
 _REPLAY_CHAR_BUDGET = 30_000
@@ -26,18 +28,6 @@ FLAT_SCHEMA = (
     "error_handling INT, cost_efficiency INT, overall_score INT, "
     "summary STRING, recommendations STRING"
 )
-
-
-def create_spark_session() -> SparkSession:
-    """Return (or reuse) the active SparkSession for this job."""
-    if os.environ.get("DATABRICKS_RUNTIME_VERSION") is None:
-        try:
-            from databricks.connect import DatabricksSession
-
-            return DatabricksSession.builder.serverless().getOrCreate()
-        except ImportError:
-            return SparkSession.builder.getOrCreate()
-    return SparkSession.builder.getOrCreate()
 
 
 def format_event_line(row) -> str:

--- a/claude_otel_session_scorer/silver_etl.py
+++ b/claude_otel_session_scorer/silver_etl.py
@@ -1,22 +1,10 @@
-import os
 from argparse import ArgumentParser
 
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql import functions as F
 from pyspark.sql.window import Window
 
-
-def create_spark_session() -> SparkSession:
-    if os.environ.get("DATABRICKS_RUNTIME_VERSION") is None:
-        try:
-            from databricks.connect import DatabricksSession
-
-            return DatabricksSession.builder.serverless().getOrCreate()
-        except ImportError:
-            print("Databricks Connect not available. Falling back to standard Spark session.")
-            return SparkSession.builder.getOrCreate()
-    else:
-        return SparkSession.builder.getOrCreate()
+from claude_otel_session_scorer._spark import create_spark_session
 
 
 def _safe_event_attr(attr_key: str):


### PR DESCRIPTION
Fixes #15.

`create_spark_session()` was copy-pasted across all runnable modules with subtly different error-handling bodies. Extracted into `claude_otel_session_scorer/_spark.py` and updated all callers to import from there.