### PR TITLE
fix: eliminate duplicate cost/active_time aggregations in silver_etl

### DIFF
--- a/claude_otel_session_scorer/silver_etl.py
+++ b/claude_otel_session_scorer/silver_etl.py
@@ -1,3 +1,5 @@
+import logging
+import os
 from argparse import ArgumentParser
 
 from pyspark.sql import DataFrame, SparkSession
@@ -5,6 +7,8 @@ from pyspark.sql import functions as F
 from pyspark.sql.window import Window
 
 from claude_otel_session_scorer._spark import create_spark_session
+
+logger = logging.getLogger(__name__)
 
 
 def _safe_event_attr(attr_key: str):
@@ -18,11 +22,8 @@ def _ensure_table_with_clustering(spark: SparkSession, full_table_name: str, df:
         )
 
 
-def _build_session_summary(
-    spark: SparkSession, bronze_traces: str, bronze_metrics: str
-) -> DataFrame:
+def _build_session_summary(spark: SparkSession, bronze_traces: str) -> DataFrame:
     traces = spark.table(bronze_traces)
-    metrics = spark.table(bronze_metrics)
 
     interactions = (
         traces.filter(F.col("name") == "claude_code.interaction")
@@ -93,24 +94,11 @@ def _build_session_summary(
             ).alias("auto_accepted"),
         )
     )
-    cost = (
-        metrics.filter(F.col("name") == "claude_code.cost.usage")
-        .groupBy(F.col("sum.attributes").getItem("session.id").alias("session_id"))
-        .agg(F.sum("sum.value").alias("total_cost_usd"))
-    )
-    active_time = (
-        metrics.filter(F.col("name") == "claude_code.active_time.total")
-        .groupBy(F.col("sum.attributes").getItem("session.id").alias("session_id"))
-        .agg(F.sum("sum.value").alias("total_active_time_s"))
-    )
-
     return (
         interactions.join(llm_stats, "session_id", "left")
         .join(tool_stats, "session_id", "left")
         .join(tool_exec, "session_id", "left")
         .join(autonomy, "session_id", "left")
-        .join(cost, "session_id", "left")
-        .join(active_time, "session_id", "left")
         .withColumn(
             "session_duration_s",
             F.unix_timestamp("session_end") - F.unix_timestamp("session_start"),
@@ -175,8 +163,6 @@ def _build_session_summary(
             "tools_per_interaction",
             "llm_calls_per_interaction",
             "avg_prompt_length",
-            "total_cost_usd",
-            "total_active_time_s",
             "service_version",
             "os_type",
             "terminal_type",
@@ -490,31 +476,7 @@ def run_silver_etl(
 
     spark.sql(f"CREATE SCHEMA IF NOT EXISTS {silver_schema}")
 
-    # session_summary — MERGE
-    summary_df = _build_session_summary(spark, bronze_traces, bronze_metrics)
-    _ensure_table_with_clustering(spark, silver_summary, summary_df)
-    summary_df.createOrReplaceTempView("session_summary_updates")
-    spark.sql(f"""
-        MERGE INTO {silver_summary} AS target
-        USING session_summary_updates AS source
-        ON target.session_id = source.session_id
-        WHEN MATCHED THEN UPDATE SET *
-        WHEN NOT MATCHED THEN INSERT *
-    """)
-    print(f"✔ {silver_summary}: {spark.table(silver_summary).count()} sessions")
-
-    # session_events — delete-then-append per session
-    events_df = _build_session_events(spark, bronze_traces, bronze_logs)
-    _ensure_table_with_clustering(spark, silver_events, events_df)
-    events_df.createOrReplaceTempView("session_events_updates")
-    events_df.select("session_id").distinct().createOrReplaceTempView("incoming_session_ids")
-    spark.sql(
-        f"DELETE FROM {silver_events} WHERE session_id IN (SELECT session_id FROM incoming_session_ids)"
-    )
-    events_df.write.mode("append").option("mergeSchema", "true").saveAsTable(silver_events)
-    print(f"✔ {silver_events}: {spark.table(silver_events).count()} events")
-
-    # session_metrics — MERGE
+    # session_metrics — built first so summary can derive cost/active_time from it (single source)
     metrics_df = _build_session_metrics(spark, bronze_metrics)
     _ensure_table_with_clustering(spark, silver_metrics, metrics_df)
     metrics_df.createOrReplaceTempView("session_metrics_updates")
@@ -525,7 +487,37 @@ def run_silver_etl(
         WHEN MATCHED THEN UPDATE SET *
         WHEN NOT MATCHED THEN INSERT *
     """)
-    print(f"✔ {silver_metrics}: {spark.table(silver_metrics).count()} sessions")
+    logger.info("Wrote session_metrics: %s", silver_metrics)
+
+    # session_summary — join cost/active_time from session_metrics (avoids double aggregation)
+    summary_df = _build_session_summary(spark, bronze_traces)
+    cost_active = metrics_df.select(
+        "session_id",
+        "total_cost_usd",
+        (F.col("active_time_cli_s") + F.col("active_time_user_s")).alias("total_active_time_s"),
+    )
+    summary_df = summary_df.join(cost_active, "session_id", "left")
+    _ensure_table_with_clustering(spark, silver_summary, summary_df)
+    summary_df.createOrReplaceTempView("session_summary_updates")
+    spark.sql(f"""
+        MERGE INTO {silver_summary} AS target
+        USING session_summary_updates AS source
+        ON target.session_id = source.session_id
+        WHEN MATCHED THEN UPDATE SET *
+        WHEN NOT MATCHED THEN INSERT *
+    """)
+    logger.info("Wrote session_summary: %s", silver_summary)
+
+    # session_events — delete-then-append per session
+    events_df = _build_session_events(spark, bronze_traces, bronze_logs)
+    _ensure_table_with_clustering(spark, silver_events, events_df)
+    events_df.createOrReplaceTempView("session_events_updates")
+    events_df.select("session_id").distinct().createOrReplaceTempView("incoming_session_ids")
+    spark.sql(
+        f"DELETE FROM {silver_events} WHERE session_id IN (SELECT session_id FROM incoming_session_ids)"
+    )
+    events_df.write.mode("append").option("mergeSchema", "true").saveAsTable(silver_events)
+    logger.info("Wrote session_events: %s", silver_events)
 
 
 def main() -> None:
@@ -548,7 +540,8 @@ def main() -> None:
     try:
         run_silver_etl(spark, args.bronze_schema, args.silver_schema)
     finally:
-        spark.stop()
+        if os.environ.get("DATABRICKS_RUNTIME_VERSION") is None:
+            spark.stop()
 
 
 if __name__ == "__main__":

--- a/tests/test_silver_etl.py
+++ b/tests/test_silver_etl.py
@@ -3,6 +3,7 @@ Tests for the silver_etl module
 """
 
 import inspect
+import os
 from unittest.mock import MagicMock, patch
 
 from claude_otel_session_scorer import silver_etl
@@ -91,9 +92,11 @@ def test_session_events_append_uses_merge_schema():
 
 
 def test_main_creates_spark_and_stops():
+    env_without_dbr = {k: v for k, v in os.environ.items() if k != "DATABRICKS_RUNTIME_VERSION"}
     with (
         patch("claude_otel_session_scorer.silver_etl.create_spark_session") as mock_create,
         patch("claude_otel_session_scorer.silver_etl.run_silver_etl") as mock_run,
+        patch.dict(os.environ, env_without_dbr, clear=True),
     ):
         mock_spark = MagicMock()
         mock_create.return_value = mock_spark
@@ -113,3 +116,44 @@ def test_main_creates_spark_and_stops():
         mock_create.assert_called_once()
         mock_run.assert_called_once_with(mock_spark, "sc.ss", "tc.ts")
         mock_spark.stop.assert_called_once()
+
+
+def test_main_does_not_stop_spark_inside_databricks():
+    """spark.stop() must be suppressed when DATABRICKS_RUNTIME_VERSION is set."""
+    with (
+        patch("claude_otel_session_scorer.silver_etl.create_spark_session") as mock_create,
+        patch("claude_otel_session_scorer.silver_etl.run_silver_etl"),
+        patch.dict(os.environ, {"DATABRICKS_RUNTIME_VERSION": "14.3"}),
+    ):
+        mock_spark = MagicMock()
+        mock_create.return_value = mock_spark
+
+        with patch("sys.argv", ["silver_etl", "--bronze-schema", "a.b", "--silver-schema", "c.d"]):
+            main()
+
+        mock_spark.stop.assert_not_called()
+
+
+def test_session_metrics_written_before_summary():
+    """session_metrics must be merged before session_summary so summary can join cost/active_time."""
+    spark = _make_mock_spark()
+    run_silver_etl(spark, "cat.src", "cat.tgt")
+    sql_calls = _sql_calls(spark)
+    metrics_pos = next(
+        i for i, s in enumerate(sql_calls) if "MERGE INTO cat.tgt.session_metrics" in s
+    )
+    summary_pos = next(
+        i for i, s in enumerate(sql_calls) if "MERGE INTO cat.tgt.session_summary" in s
+    )
+    assert metrics_pos < summary_pos, "session_metrics MERGE must precede session_summary MERGE"
+
+
+def test_summary_derives_cost_and_active_time_from_metrics():
+    """run_silver_etl must join cost/active_time from metrics_df rather than re-aggregating."""
+    src = inspect.getsource(silver_etl.run_silver_etl)
+    # The summary builder should no longer receive bronze_metrics
+    assert "_build_session_summary(spark, bronze_traces)" in src
+    # cost and active_time must be derived via a join from the metrics DataFrame
+    assert "active_time_cli_s" in src
+    assert "active_time_user_s" in src
+    assert "total_active_time_s" in src


### PR DESCRIPTION
## Summary

- **Closes #14** — eliminates the double-aggregation of `total_cost_usd` and `total_active_time_s`. `_build_session_summary` previously re-aggregated these from bronze metrics; now `session_metrics` is built first and its DataFrame is joined into `session_summary` to derive both values. `active_time_cli_s + active_time_user_s` from session_metrics becomes `total_active_time_s` in the summary. Single source of truth, no silent drift possible.
- **Closes #19 (item 1)** — replaced three `print(f"✔ ...: {spark.table(...).count()} ...")` calls (full table scans) with `logger.info(...)` messages that log the table name without triggering a count. The temp views already carry the written rows; there is no need to re-scan the target table.
- **Closes #19 (item 6)** — `spark.stop()` in `main()` is now guarded by `if os.environ.get("DATABRICKS_RUNTIME_VERSION") is None:`, matching the existing pattern in `scorer.py` and `human_signals.py`. This prevents premature session termination when running inside a Databricks cluster.

## Test plan

- [ ] `test_main_creates_spark_and_stops` — still passes; `DATABRICKS_RUNTIME_VERSION` is explicitly cleared via `patch.dict`, so `stop()` is called exactly once.
- [ ] `test_main_does_not_stop_spark_inside_databricks` (new) — verifies `stop()` is suppressed when the env var is set.
- [ ] `test_session_metrics_written_before_summary` (new) — asserts the metrics MERGE SQL appears before the summary MERGE SQL in the call list.
- [ ] `test_summary_derives_cost_and_active_time_from_metrics` (new) — source-inspects `run_silver_etl` to confirm the summary builder receives only `bronze_traces` and the cost/active_time join variables are present.
- [ ] All pre-existing tests (`test_session_summary_merge`, `test_session_metrics_merge`, `test_session_events_delete_then_append`, source-inspection tests) continue to pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)